### PR TITLE
Add sample capabilities

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,6 +77,8 @@ subprojects {
     group = "org.quiltmc.quilt-kotlin-libraries"
     version = projectVersion
 
+    val samples by sourceSets.creating
+
     dependencies {
         minecraft(rootProject.libs.minecraft)
         mappings(loom.layered {
@@ -86,6 +88,21 @@ subprojects {
         modImplementation(rootProject.libs.quilt.loader)
 
         modImplementation(rootProject.libs.qsl)
+
+        // Get samples to depend on main and its dependencies
+        val main = sourceSets.main.get()
+        "samplesImplementation"(main.output)
+        "samplesImplementation"(main.compileClasspath)
+    }
+
+    // Fix weird IDEA error when trying to work with samples
+    afterEvaluate {
+        if (System.getProperty("idea.sync.active") != null) {
+            println("Creating sample source set folders to circumvent IDEA error")
+            samples.allSource.srcDirs.forEach {
+                it.mkdirs()
+            }
+        }
     }
 
     tasks {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,7 +98,6 @@ subprojects {
     // Fix weird IDEA error when trying to work with samples
     afterEvaluate {
         if (System.getProperty("idea.sync.active") != null) {
-            println("Creating sample source set folders to circumvent IDEA error")
             samples.allSource.srcDirs.forEach {
                 it.mkdirs()
             }

--- a/core/src/samples/kotlin/org/quiltmc/qkl/core/samples/KotlinAdapterExample.kt
+++ b/core/src/samples/kotlin/org/quiltmc/qkl/core/samples/KotlinAdapterExample.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qkl.core.samples
+
+import org.quiltmc.loader.api.ModContainer
+import org.quiltmc.qkl.core.adapter.KotlinAdapter
+import org.quiltmc.qsl.base.api.entrypoint.ModInitializer
+import org.slf4j.LoggerFactory
+
+/**
+ * An example usage of [KotlinAdapter]. The `quilt.mod.json` may look similar to:
+ * ```json
+ * // ...
+ * "entrypoints": [
+ *     "init": {
+ *         "adapter": "kotlin",
+ *         "value": "org.quiltmc.qkl.core.samples.KotlinAdapterExample"
+ *     }
+ * ]
+ * // ...
+ * "depends": {
+ *     "qkl": ">=0.1.0"
+ * }
+ * // ...
+ * ```
+ */
+object KotlinAdapterExample : ModInitializer {
+    override fun onInitialize(mod: ModContainer) {
+        LoggerFactory.getLogger("example").info("Kotlin's adapter lets you use objects as initializers!")
+    }
+}


### PR DESCRIPTION
With this, any module can create sample classes and functions to demonstrate behavior that otherwise may be too complex to describe in raw documentation