### PR TITLE
Fix remapping by making included modules be `namedElements`

### DIFF
--- a/fatjar/build.gradle.kts
+++ b/fatjar/build.gradle.kts
@@ -7,9 +7,9 @@ fun DependencyHandlerScope.includeApi(dependency: Any) {
 }
 
 dependencies {
-    includeApi(project(":core"))
-    includeApi(project(":wrapper:qsl"))
-    includeApi(project(":wrapper:minecraft"))
+    include(modApi(project(":core",              configuration = "namedElements"))!!)
+    include(modApi(project(":wrapper:qsl",       configuration = "namedElements"))!!)
+    include(modApi(project(":wrapper:minecraft", configuration = "namedElements"))!!)
 }
 
 tasks.remapJar {

--- a/fatjar/build.gradle.kts
+++ b/fatjar/build.gradle.kts
@@ -2,14 +2,14 @@ plugins {
     id("org.quiltmc.loom")
 }
 
-fun DependencyHandlerScope.includeApi(dependency: Any) {
-    include(dependency)?.let { implementation(it) }
+fun DependencyHandlerScope.includeProject(projectId: String) {
+    include(modApi(project(projectId, configuration = "namedElements"))!!)
 }
 
 dependencies {
-    include(modApi(project(":core",              configuration = "namedElements"))!!)
-    include(modApi(project(":wrapper:qsl",       configuration = "namedElements"))!!)
-    include(modApi(project(":wrapper:minecraft", configuration = "namedElements"))!!)
+    includeProject(":core")
+    includeProject(":wrapper:qsl")
+    includeProject(":wrapper:minecraft")
 }
 
 tasks.remapJar {


### PR DESCRIPTION
Tested locally and seems to work

Thanks to @jakobkmar for providing the fix for this on discord