### PR TITLE
Refine Registry DSL, add samples

### DIFF
--- a/wrapper/minecraft/src/main/kotlin/samples/qkl/brigadier/BrigadierDslSamples.kt
+++ b/wrapper/minecraft/src/main/kotlin/samples/qkl/brigadier/BrigadierDslSamples.kt
@@ -48,15 +48,15 @@ private object BrigadierDslSamples {
         val dispatcher: CommandDispatcher<ServerCommandSource> = stub()
 
         dispatcher.register("echo") {
-            //register arguments with extension methods
+            // Register arguments with extension methods
             required(string("message")) { message -> // treat the argument as a key
                 required(boolean("toCaps")) { getToCaps -> // or as an accessor
-                    //standard builder methods can be called as normal
+                    // Standard builder methods can be called as normal
                     requires {
                         it.player.experienceLevel > Random.nextInt()
                     }
 
-                    //execute the command with an extension method
+                    // Execute the command with an extension method
                     execute {
                         val response = if (getToCaps().value()) {
                             this[message].value().uppercase()
@@ -64,7 +64,7 @@ private object BrigadierDslSamples {
                             this[message].value()
                         }
 
-                        //use utility extensions for common actions
+                        // Use utility extensions for common actions
                         sendFeedback(Text.literal(response))
                     }
                 }
@@ -73,16 +73,16 @@ private object BrigadierDslSamples {
     }
 
     fun sampleCustomCommandSource() {
-        //some special command source your code needs
-        //e.g. commands coming from external integrations
+        // Some special command source your code needs
+        // e.g. commands coming from external integrations
         abstract class CustomSource {
             abstract fun calculateVec3(pos: PosArgument): Vec3d
 
             abstract fun useVec3ForSomething(vec: Vec3d)
         }
 
-        //can use any name including `value`
-        //`custom` added for clarity
+        // Can use any name including `value`
+        // `custom` added for clarity
         fun ArgumentReader<CustomSource, DefaultArgumentDescriptor<Vec3ArgumentType>>.customValue(): Vec3d =
             context.source.calculateVec3(posArgument())
 
@@ -133,7 +133,7 @@ private object BrigadierDslSamples {
                 ) { getWeapon ->
                     optional(literal("repeatedly")) { repeatedly ->
                         execute {
-                            //operator access is nullable only for optionals
+                            // Operator access is nullable only for optionals
                             val targetName = this[target]?.value()?.displayName ?: Text.literal("themselves")
 
                             server.playerManager.broadcastSystemMessage(

--- a/wrapper/minecraft/src/main/kotlin/samples/qkl/registry/RegistryDslSamples.kt
+++ b/wrapper/minecraft/src/main/kotlin/samples/qkl/registry/RegistryDslSamples.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package samples.qkl.registry
+
+import net.minecraft.item.Item
+import net.minecraft.util.Identifier
+import net.minecraft.util.registry.Registry
+import org.quiltmc.qkl.wrapper.minecraft.registry.invoke
+import org.quiltmc.qkl.wrapper.minecraft.registry.withId
+import org.quiltmc.qkl.wrapper.minecraft.registry.registryScope
+
+/**
+ * Container for samples. Functions can be referenced
+ * by their full name in the @sample KDoc tag to
+ * inject the body as a documentation sample.
+ *
+ * @author Peanuuutz
+ */
+@Suppress("unused")
+private object RegistryDslSamples {
+    fun <T> stub(): T {
+        error("Sample utility should not be called")
+    }
+
+    fun sampleRegisterGlobally() {
+        val item: Item = stub()
+        val identifier: Identifier = stub()
+
+        item withId identifier toRegistry Registry.ITEM
+    }
+
+    fun sampleRegisterWithRegistry() {
+        val item: Item = stub()
+        val identifier = Identifier("my", "item1")
+
+        Registry.ITEM("my") {
+            item withId identifier // Goes under `my:item1`
+            item withId "my:item2" // Goes under `my:item2`
+            item withId "item3" // Goes under `my:item3`
+        }
+
+        Registry.ITEM {
+            item withId identifier // Goes under `my:item1`
+            item withId "my:item2" // Goes under `my:item2`
+            item withId "item3" // Goes under `minecraft:item3`
+        }
+    }
+
+    fun sampleRegisterWithScope() {
+        val item: Item = stub()
+        val identifier = Identifier("my", "item1")
+
+        registryScope("my") {
+            Registry.ITEM {
+                item withId identifier // Goes under `my:item1`
+                item withId "my:item2" // Goes under `my:item2`
+                item withId "item3" // Goes under `my:item3`
+            }
+
+            item withPath "item3" toRegistry Registry.ITEM
+        }
+    }
+}


### PR DESCRIPTION
Closes #29.

Major changes:
* `name` -> `path`: to match Identifier field name and be more generic.
* `RegistryAction.withName` is replaced with `.withId` and resolves #29.
* `RegistryDsl` now is a DSL annotation. Previous is replaced with `RegistryScope` and corresponding `registryScope` utility function.
* `inline` functions which take in lambda parameter.
* Add samples to some of the main functions.