### PR TITLE
Refine/improve math operators

### DIFF
--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/BlockPosOps.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/BlockPosOps.kt
@@ -18,6 +18,8 @@ package org.quiltmc.qkl.wrapper.minecraft.math
 
 import net.minecraft.client.util.math.Vector3d
 import net.minecraft.util.math.BlockPos
+import net.minecraft.util.math.Vec3d
+import net.minecraft.util.math.Vec3f
 import net.minecraft.util.math.Vec3i
 
 //region Standard math operators
@@ -187,5 +189,51 @@ public operator fun BlockPos.component2(): Int {
  */
 public operator fun BlockPos.component3(): Int {
     return this.z
+}
+//endregion
+
+//region Conversion methods
+/**
+ * Converts a [BlockPos] to a [Vec3d].
+ */
+public fun BlockPos.toVec3d(): Vec3d {
+    return Vec3d(
+        this.x.toDouble(),
+        this.y.toDouble(),
+        this.z.toDouble()
+    )
+}
+
+/**
+ * Converts a [BlockPos] to a [Vec3f].
+ */
+public fun BlockPos.toVec3f(): Vec3f {
+    return Vec3f(
+        this.x.toFloat(),
+        this.y.toFloat(),
+        this.z.toFloat()
+    )
+}
+
+/**
+ * Converts a [BlockPos] to a [Vec3i].
+ */
+public fun BlockPos.toVec3i(): Vec3i {
+    return Vec3i(
+        this.x,
+        this.y,
+        this.z
+    )
+}
+
+/**
+ * Converts a [BlockPos] to a [Vector3d].
+ */
+public fun BlockPos.toVector3d(): Vector3d {
+    return Vector3d(
+        this.x.toDouble(),
+        this.y.toDouble(),
+        this.z.toDouble()
+    )
 }
 //endregion

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/BlockPosOps.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/BlockPosOps.kt
@@ -16,11 +16,9 @@
 
 package org.quiltmc.qkl.wrapper.minecraft.math
 
-import net.minecraft.util.math.Vec3d
-import net.minecraft.util.math.Vec3f
-import net.minecraft.util.math.Vec3i
-import net.minecraft.util.math.BlockPos
 import net.minecraft.client.util.math.Vector3d
+import net.minecraft.util.math.BlockPos
+import net.minecraft.util.math.Vec3i
 
 //region Standard math operators
 /**
@@ -100,28 +98,6 @@ public operator fun BlockPos.unaryMinus(): BlockPos {
 
 //region Type compatibility operator variations
 /**
- * Adds a [Vec3d] to a [BlockPos].
- */
-public operator fun BlockPos.plus(other: Vec3d): BlockPos {
-    return BlockPos(
-        this.x + other.x.toInt(),
-        this.y + other.y.toInt(),
-        this.z + other.z.toInt()
-    )
-}
-
-/**
- * Adds a [Vec3f] to a [BlockPos].
- */
-public operator fun BlockPos.plus(other: Vec3f): BlockPos {
-    return BlockPos(
-        this.x + other.x.toInt(),
-        this.y + other.y.toInt(),
-        this.z + other.z.toInt()
-    )
-}
-
-/**
  * Adds a [Vec3i] to a [BlockPos].
  */
 public operator fun BlockPos.plus(other: Vec3i): BlockPos {
@@ -129,39 +105,6 @@ public operator fun BlockPos.plus(other: Vec3i): BlockPos {
         this.x + other.x,
         this.y + other.y,
         this.z + other.z
-    )
-}
-
-/**
- * Adds a [Vector3d] to a [BlockPos].
- */
-public operator fun BlockPos.plus(other: Vector3d): BlockPos {
-    return BlockPos(
-        this.x + other.x.toInt(),
-        this.y + other.y.toInt(),
-        this.z + other.z.toInt()
-    )
-}
-
-/**
- * Subtracts a [Vec3d] from a [BlockPos].
- */
-public operator fun BlockPos.minus(other: Vec3d): BlockPos {
-    return BlockPos(
-        this.x - other.x.toInt(),
-        this.y - other.y.toInt(),
-        this.z - other.z.toInt()
-    )
-}
-
-/**
- * Subtracts a [Vec3f] from a [BlockPos].
- */
-public operator fun BlockPos.minus(other: Vec3f): BlockPos {
-    return BlockPos(
-        this.x - other.x.toInt(),
-        this.y - other.y.toInt(),
-        this.z - other.z.toInt()
     )
 }
 
@@ -177,41 +120,6 @@ public operator fun BlockPos.minus(other: Vec3i): BlockPos {
 }
 
 /**
- * Subtracts a [Vector3d] from a [BlockPos].
- */
-public operator fun BlockPos.minus(other: Vector3d): BlockPos {
-    return BlockPos(
-        this.x - other.x.toInt(),
-        this.y - other.y.toInt(),
-        this.z - other.z.toInt()
-    )
-}
-
-/**
- * Multiplies a [BlockPos] and a [Vec3d].
- * This method is a shorthand for component wise multiplication.
- */
-public operator fun BlockPos.times(other: Vec3d): BlockPos {
-    return BlockPos(
-        this.x * other.x.toInt(),
-        this.y * other.y.toInt(),
-        this.z * other.z.toInt()
-    )
-}
-
-/**
- * Multiplies a [BlockPos] and a [Vec3f].
- * This method is a shorthand for component wise multiplication.
- */
-public operator fun BlockPos.times(other: Vec3f): BlockPos {
-    return BlockPos(
-        this.x * other.x.toInt(),
-        this.y * other.y.toInt(),
-        this.z * other.z.toInt()
-    )
-}
-
-/**
  * Multiplies a [BlockPos] and a [Vec3i].
  * This method is a shorthand for component wise multiplication.
  */
@@ -222,33 +130,14 @@ public operator fun BlockPos.times(other: Vec3i): BlockPos {
         this.z * other.z
     )
 }
-
-/**
- * Multiplies a [BlockPos] and a [Vector3d].
- * This method is a shorthand for component wise multiplication.
- */
-public operator fun BlockPos.times(other: Vector3d): BlockPos {
-    return BlockPos(
-        this.x * other.x.toInt(),
-        this.y * other.y.toInt(),
-        this.z * other.z.toInt()
-    )
-}
 //endregion
 
 //region Vector specific operators
 /**
- * The cross product of a [BlockPos] and a [Vec3d].
+ * The dot product of a [BlockPos] and a [Vec3i].
  */
-public infix fun BlockPos.cross(other: Vec3d): BlockPos {
-    return this.crossProduct(Vec3i(other.x, other.y, other.z))
-}
-
-/**
- * The cross product of a [BlockPos] and a [Vec3f].
- */
-public infix fun BlockPos.cross(other: Vec3f): BlockPos {
-    return this.crossProduct(Vec3i(other.x.toDouble(), other.y.toDouble(), other.z.toDouble()))
+public infix fun BlockPos.dot(other: Vec3i): Int {
+    return x * other.x + y * other.y + z * other.z
 }
 
 /**
@@ -256,6 +145,13 @@ public infix fun BlockPos.cross(other: Vec3f): BlockPos {
  */
 public infix fun BlockPos.cross(other: Vec3i): BlockPos {
     return this.crossProduct(other)
+}
+
+/**
+ * The dot product of a [BlockPos] and a [BlockPos].
+ */
+public infix fun BlockPos.dot(other: BlockPos): Int {
+    return x * other.x + y * other.y + z * other.z
 }
 
 /**

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/BlockPosOps.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/BlockPosOps.kt
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qkl.wrapper.minecraft.math
+
+import net.minecraft.util.math.Vec3d
+import net.minecraft.util.math.Vec3f
+import net.minecraft.util.math.Vec3i
+import net.minecraft.util.math.BlockPos
+import net.minecraft.client.util.math.Vector3d
+
+//region Standard math operators
+/**
+ * Adds a [BlockPos] to a [BlockPos].
+ */
+public operator fun BlockPos.plus(other: BlockPos): BlockPos {
+    return BlockPos(
+        this.x + other.x,
+        this.y + other.y,
+        this.z + other.z
+    )
+}
+
+/**
+ * Subtracts a [BlockPos] from a [BlockPos].
+ */
+public operator fun BlockPos.minus(other: BlockPos): BlockPos {
+    return BlockPos(
+        this.x - other.x,
+        this.y - other.y,
+        this.z - other.z
+    )
+}
+
+/**
+ * Multiplies a [BlockPos] and a [BlockPos].
+ * This method is a shorthand for component wise multiplication.
+ */
+public operator fun BlockPos.times(other: BlockPos): BlockPos {
+    return BlockPos(
+        this.x * other.x,
+        this.y * other.y,
+        this.z * other.z
+    )
+}
+
+/**
+ * Multiplies a [BlockPos] and an Int.
+ */
+public operator fun BlockPos.times(other: Int): BlockPos {
+    return BlockPos(
+        this.x * other,
+        this.y * other,
+        this.z * other
+    )
+}
+
+/**
+ * Multiplies an Int and a [BlockPos].
+ */
+public operator fun Int.times(other: BlockPos): BlockPos {
+    return BlockPos(
+        this * other.x,
+        this * other.y,
+        this * other.z
+    )
+}
+
+/**
+ * Divides a [BlockPos] and an Int.
+ */
+public operator fun BlockPos.div(other: Int): BlockPos {
+    return BlockPos(
+        this.x / other,
+        this.y / other,
+        this.z / other
+    )
+}
+
+/**
+ * Negates a [BlockPos].
+ */
+public operator fun BlockPos.unaryMinus(): BlockPos {
+    return this.times(-1)
+}
+//endregion
+
+//region Type compatibility operator variations
+/**
+ * Adds a [Vec3d] to a [BlockPos].
+ */
+public operator fun BlockPos.plus(other: Vec3d): BlockPos {
+    return BlockPos(
+        this.x + other.x.toInt(),
+        this.y + other.y.toInt(),
+        this.z + other.z.toInt()
+    )
+}
+
+/**
+ * Adds a [Vec3f] to a [BlockPos].
+ */
+public operator fun BlockPos.plus(other: Vec3f): BlockPos {
+    return BlockPos(
+        this.x + other.x.toInt(),
+        this.y + other.y.toInt(),
+        this.z + other.z.toInt()
+    )
+}
+
+/**
+ * Adds a [Vec3i] to a [BlockPos].
+ */
+public operator fun BlockPos.plus(other: Vec3i): BlockPos {
+    return BlockPos(
+        this.x + other.x,
+        this.y + other.y,
+        this.z + other.z
+    )
+}
+
+/**
+ * Adds a [Vector3d] to a [BlockPos].
+ */
+public operator fun BlockPos.plus(other: Vector3d): BlockPos {
+    return BlockPos(
+        this.x + other.x.toInt(),
+        this.y + other.y.toInt(),
+        this.z + other.z.toInt()
+    )
+}
+
+/**
+ * Subtracts a [Vec3d] from a [BlockPos].
+ */
+public operator fun BlockPos.minus(other: Vec3d): BlockPos {
+    return BlockPos(
+        this.x - other.x.toInt(),
+        this.y - other.y.toInt(),
+        this.z - other.z.toInt()
+    )
+}
+
+/**
+ * Subtracts a [Vec3f] from a [BlockPos].
+ */
+public operator fun BlockPos.minus(other: Vec3f): BlockPos {
+    return BlockPos(
+        this.x - other.x.toInt(),
+        this.y - other.y.toInt(),
+        this.z - other.z.toInt()
+    )
+}
+
+/**
+ * Subtracts a [Vec3i] from a [BlockPos].
+ */
+public operator fun BlockPos.minus(other: Vec3i): BlockPos {
+    return BlockPos(
+        this.x - other.x,
+        this.y - other.y,
+        this.z - other.z
+    )
+}
+
+/**
+ * Subtracts a [Vector3d] from a [BlockPos].
+ */
+public operator fun BlockPos.minus(other: Vector3d): BlockPos {
+    return BlockPos(
+        this.x - other.x.toInt(),
+        this.y - other.y.toInt(),
+        this.z - other.z.toInt()
+    )
+}
+
+/**
+ * Multiplies a [BlockPos] and a [Vec3d].
+ * This method is a shorthand for component wise multiplication.
+ */
+public operator fun BlockPos.times(other: Vec3d): BlockPos {
+    return BlockPos(
+        this.x * other.x.toInt(),
+        this.y * other.y.toInt(),
+        this.z * other.z.toInt()
+    )
+}
+
+/**
+ * Multiplies a [BlockPos] and a [Vec3f].
+ * This method is a shorthand for component wise multiplication.
+ */
+public operator fun BlockPos.times(other: Vec3f): BlockPos {
+    return BlockPos(
+        this.x * other.x.toInt(),
+        this.y * other.y.toInt(),
+        this.z * other.z.toInt()
+    )
+}
+
+/**
+ * Multiplies a [BlockPos] and a [Vec3i].
+ * This method is a shorthand for component wise multiplication.
+ */
+public operator fun BlockPos.times(other: Vec3i): BlockPos {
+    return BlockPos(
+        this.x * other.x,
+        this.y * other.y,
+        this.z * other.z
+    )
+}
+
+/**
+ * Multiplies a [BlockPos] and a [Vector3d].
+ * This method is a shorthand for component wise multiplication.
+ */
+public operator fun BlockPos.times(other: Vector3d): BlockPos {
+    return BlockPos(
+        this.x * other.x.toInt(),
+        this.y * other.y.toInt(),
+        this.z * other.z.toInt()
+    )
+}
+//endregion
+
+//region Vector specific operators
+/**
+ * The cross product of a [BlockPos] and a [Vec3d].
+ */
+public infix fun BlockPos.cross(other: Vec3d): BlockPos {
+    return this.crossProduct(Vec3i(other.x, other.y, other.z))
+}
+
+/**
+ * The cross product of a [BlockPos] and a [Vec3f].
+ */
+public infix fun BlockPos.cross(other: Vec3f): BlockPos {
+    return this.crossProduct(Vec3i(other.x.toDouble(), other.y.toDouble(), other.z.toDouble()))
+}
+
+/**
+ * The cross product of a [BlockPos] and a [Vec3i].
+ */
+public infix fun BlockPos.cross(other: Vec3i): BlockPos {
+    return this.crossProduct(other)
+}
+
+/**
+ * The cross product of a [BlockPos] and a [BlockPos].
+ */
+public infix fun BlockPos.cross(other: BlockPos): BlockPos {
+    return this.crossProduct(other)
+}
+
+/**
+ * The cross product of a [BlockPos] and a [Vector3d].
+ */
+public infix fun BlockPos.cross(other: Vector3d): BlockPos {
+    return this.crossProduct(Vec3i(other.x, other.y, other.z))
+}
+
+/**
+ * The [`x`][BlockPos.x] component of a [BlockPos].
+ */
+public operator fun BlockPos.component1(): Int {
+    return this.x
+}
+
+/**
+ * The [`y`][BlockPos.y] component of a [BlockPos].
+ */
+public operator fun BlockPos.component2(): Int {
+    return this.y
+}
+
+/**
+ * The [`z`][BlockPos.z] component of a [BlockPos].
+ */
+public operator fun BlockPos.component3(): Int {
+    return this.z
+}
+//endregion

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/InternalUtil.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/InternalUtil.kt
@@ -16,4 +16,7 @@
 
 package org.quiltmc.qkl.wrapper.minecraft.math
 
+/**
+ * This value is used in vector operations to return the 0 vector instead when it gets too small
+ */
 internal const val EPSILON = 1.0E-4

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/InternalUtil.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/InternalUtil.kt
@@ -17,6 +17,6 @@
 package org.quiltmc.qkl.wrapper.minecraft.math
 
 /**
- * This value is used in vector operations to return the 0 vector instead when it gets too small
+ * This value is used in vector operations to return the 0 vector instead when it gets too small.
  */
 internal const val EPSILON = 1.0E-4

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Matrix3f.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Matrix3f.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qkl.wrapper.minecraft.math
+
+import net.minecraft.util.math.Matrix3f
+import net.minecraft.util.math.Quaternion
+
+/**
+ * Adds a [Matrix3f] and a [Matrix3f].
+ */
+public operator fun Matrix3f.plusAssign(other: Matrix3f) {
+    this.add(other)
+}
+
+/**
+ * Subtracts a [Matrix3f] from a [Matrix3f].
+ */
+public operator fun Matrix3f.minusAssign(other: Matrix3f) {
+    this.subtract(other)
+}
+
+/**
+ * Multiplies a [Matrix3f] and a [Matrix3f].
+ */
+public operator fun Matrix3f.timesAssign(other: Matrix3f) {
+    this.multiply(other)
+}
+
+/**
+ * Multiplies a [Float] and a [Matrix3f].
+ */
+public operator fun Matrix3f.timesAssign(other: Float) {
+    this.multiply(other)
+}
+
+/**
+ * Multiplies a [Quaternion] and a [Matrix3f].
+ */
+public operator fun Matrix3f.timesAssign(other: Quaternion) {
+    this.multiply(other)
+}

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Matrix4f.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Matrix4f.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qkl.wrapper.minecraft.math
+
+import net.minecraft.util.math.Matrix4f
+import net.minecraft.util.math.Quaternion
+
+/**
+ * Adds a [Matrix4f] and a [Matrix4f].
+ */
+public operator fun Matrix4f.plusAssign(other: Matrix4f) {
+    this.add(other)
+}
+
+/**
+ * Subtracts a [Matrix4f] from a [Matrix4f].
+ */
+public operator fun Matrix4f.minusAssign(other: Matrix4f) {
+    this.subtract(other)
+}
+
+/**
+ * Multiplies a [Matrix4f] and a [Matrix4f].
+ */
+public operator fun Matrix4f.timesAssign(other: Matrix4f) {
+    this.multiply(other)
+}
+
+/**
+ * Multiplies a [Float] and a [Matrix4f].
+ */
+public operator fun Matrix4f.timesAssign(other: Float) {
+    this.multiply(other)
+}
+
+/**
+ * Multiplies a [Quaternion] and a [Matrix4f].
+ */
+public operator fun Matrix4f.timesAssign(other: Quaternion) {
+    this.multiply(other)
+}

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec2fOps.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec2fOps.kt
@@ -151,3 +151,15 @@ public operator fun Vec2f.component2(): Float {
     return this.y
 }
 //endregion
+
+//region Conversion methods
+/**
+ * Converts a [Vec2f] to a [Vector2f].
+ */
+public fun Vec2f.toVector2f(): Vector2f {
+    return Vector2f(
+        this.x,
+        this.y
+    )
+}
+//endregion

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec2fOps.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec2fOps.kt
@@ -62,6 +62,16 @@ public operator fun Vec2f.times(other: Float): Vec2f {
 }
 
 /**
+ * Multiplies a Float and a [Vec2f].
+ */
+public operator fun Float.times(other: Vec2f): Vec2f {
+    return Vec2f(
+        this * other.x,
+        this * other.y
+    )
+}
+
+/**
  * Divides a [Vec2f] and a Float.
  */
 public operator fun Vec2f.div(other: Float): Vec2f {

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec3dOps.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec3dOps.kt
@@ -16,11 +16,8 @@
 
 package org.quiltmc.qkl.wrapper.minecraft.math
 
-import net.minecraft.util.math.Vec3d
-import net.minecraft.util.math.Vec3f
-import net.minecraft.util.math.Vec3i
-import net.minecraft.util.math.BlockPos
 import net.minecraft.client.util.math.Vector3d
+import net.minecraft.util.math.Vec3d
 
 //region Standard math operators
 /**
@@ -100,39 +97,6 @@ public operator fun Vec3d.unaryMinus(): Vec3d {
 
 //region Type compatibility operator variations
 /**
- * Adds a [Vec3f] to a [Vec3d].
- */
-public operator fun Vec3d.plus(other: Vec3f): Vec3d {
-    return Vec3d(
-        this.x + other.x.toDouble(),
-        this.y + other.y.toDouble(),
-        this.z + other.z.toDouble()
-    )
-}
-
-/**
- * Adds a [Vec3i] to a [Vec3d].
- */
-public operator fun Vec3d.plus(other: Vec3i): Vec3d {
-    return Vec3d(
-        this.x + other.x.toDouble(),
-        this.y + other.y.toDouble(),
-        this.z + other.z.toDouble()
-    )
-}
-
-/**
- * Adds a [BlockPos] to a [Vec3d].
- */
-public operator fun Vec3d.plus(other: BlockPos): Vec3d {
-    return Vec3d(
-        this.x + other.x.toDouble(),
-        this.y + other.y.toDouble(),
-        this.z + other.z.toDouble()
-    )
-}
-
-/**
  * Adds a [Vector3d] to a [Vec3d].
  */
 public operator fun Vec3d.plus(other: Vector3d): Vec3d {
@@ -144,39 +108,6 @@ public operator fun Vec3d.plus(other: Vector3d): Vec3d {
 }
 
 /**
- * Subtracts a [Vec3f] from a [Vec3d].
- */
-public operator fun Vec3d.minus(other: Vec3f): Vec3d {
-    return Vec3d(
-        this.x - other.x.toDouble(),
-        this.y - other.y.toDouble(),
-        this.z - other.z.toDouble()
-    )
-}
-
-/**
- * Subtracts a [Vec3i] from a [Vec3d].
- */
-public operator fun Vec3d.minus(other: Vec3i): Vec3d {
-    return Vec3d(
-        this.x - other.x.toDouble(),
-        this.y - other.y.toDouble(),
-        this.z - other.z.toDouble()
-    )
-}
-
-/**
- * Subtracts a [BlockPos] from a [Vec3d].
- */
-public operator fun Vec3d.minus(other: BlockPos): Vec3d {
-    return Vec3d(
-        this.x - other.x.toDouble(),
-        this.y - other.y.toDouble(),
-        this.z - other.z.toDouble()
-    )
-}
-
-/**
  * Subtracts a [Vector3d] from a [Vec3d].
  */
 public operator fun Vec3d.minus(other: Vector3d): Vec3d {
@@ -184,42 +115,6 @@ public operator fun Vec3d.minus(other: Vector3d): Vec3d {
         this.x - other.x,
         this.y - other.y,
         this.z - other.z
-    )
-}
-
-/**
- * Multiplies a [Vec3d] and a [Vec3f].
- * This method is a shorthand for component wise multiplication.
- */
-public operator fun Vec3d.times(other: Vec3f): Vec3d {
-    return Vec3d(
-        this.x * other.x.toDouble(),
-        this.y * other.y.toDouble(),
-        this.z * other.z.toDouble()
-    )
-}
-
-/**
- * Multiplies a [Vec3d] and a [Vec3i].
- * This method is a shorthand for component wise multiplication.
- */
-public operator fun Vec3d.times(other: Vec3i): Vec3d {
-    return Vec3d(
-        this.x * other.x.toDouble(),
-        this.y * other.y.toDouble(),
-        this.z * other.z.toDouble()
-    )
-}
-
-/**
- * Multiplies a [Vec3d] and a [BlockPos].
- * This method is a shorthand for component wise multiplication.
- */
-public operator fun Vec3d.times(other: BlockPos): Vec3d {
-    return Vec3d(
-        this.x * other.x.toDouble(),
-        this.y * other.y.toDouble(),
-        this.z * other.z.toDouble()
     )
 }
 
@@ -249,48 +144,6 @@ public infix fun Vec3d.dot(other: Vec3d): Double {
  */
 public infix fun Vec3d.cross(other: Vec3d): Vec3d {
     return this.crossProduct(other)
-}
-
-/**
- * The dot product of a [Vec3d] and a [Vec3f].
- */
-public infix fun Vec3d.dot(other: Vec3f): Double {
-    return this.dotProduct(Vec3d(other))
-}
-
-/**
- * The cross product of a [Vec3d] and a [Vec3f].
- */
-public infix fun Vec3d.cross(other: Vec3f): Vec3d {
-    return this.crossProduct(Vec3d(other))
-}
-
-/**
- * The dot product of a [Vec3d] and a [Vec3i].
- */
-public infix fun Vec3d.dot(other: Vec3i): Double {
-    return this.dotProduct(Vec3d.of(other))
-}
-
-/**
- * The cross product of a [Vec3d] and a [Vec3i].
- */
-public infix fun Vec3d.cross(other: Vec3i): Vec3d {
-    return this.crossProduct(Vec3d.of(other))
-}
-
-/**
- * The dot product of a [Vec3d] and a [BlockPos].
- */
-public infix fun Vec3d.dot(other: BlockPos): Double {
-    return this.dotProduct(Vec3d.of(other))
-}
-
-/**
- * The cross product of a [Vec3d] and a [BlockPos].
- */
-public infix fun Vec3d.cross(other: BlockPos): Vec3d {
-    return this.crossProduct(Vec3d.of(other))
 }
 
 /**

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec3dOps.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec3dOps.kt
@@ -17,7 +17,10 @@
 package org.quiltmc.qkl.wrapper.minecraft.math
 
 import net.minecraft.client.util.math.Vector3d
+import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Vec3d
+import net.minecraft.util.math.Vec3f
+import net.minecraft.util.math.Vec3i
 
 //region Standard math operators
 /**
@@ -179,5 +182,51 @@ public operator fun Vec3d.component2(): Double {
  */
 public operator fun Vec3d.component3(): Double {
     return this.z
+}
+//endregion
+
+//region Conversion methods
+/**
+ * Converts a [Vec3d] to a [Vec3f].
+ */
+public fun Vec3d.toVec3f(): Vec3f {
+    return Vec3f(
+        this.x.toFloat(),
+        this.y.toFloat(),
+        this.z.toFloat()
+    )
+}
+
+/**
+ * Converts a [Vec3d] to a [Vec3i].
+ */
+public fun Vec3d.toVec3i(): Vec3i {
+    return Vec3i(
+        this.x.toInt(),
+        this.y.toInt(),
+        this.z.toInt()
+    )
+}
+
+/**
+ * Converts a [Vec3d] to a [BlockPos].
+ */
+public fun Vec3d.toBlockPos(): BlockPos {
+    return BlockPos(
+        this.x.toInt(),
+        this.y.toInt(),
+        this.z.toInt()
+    )
+}
+
+/**
+ * Converts a [Vec3d] to a [Vector3d].
+ */
+public fun Vec3d.toVector3d(): Vector3d {
+    return Vector3d(
+        this.x,
+        this.y,
+        this.z
+    )
 }
 //endregion

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec3dOps.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec3dOps.kt
@@ -68,6 +68,17 @@ public operator fun Vec3d.times(other: Double): Vec3d {
 }
 
 /**
+ * Multiplies a Double and a [Vec3d].
+ */
+public operator fun Double.times(other: Vec3d): Vec3d {
+    return Vec3d(
+        this * other.x,
+        this * other.y,
+        this * other.z
+    )
+}
+
+/**
  * Divides a [Vec3d] and a Double.
  */
 public operator fun Vec3d.div(other: Double): Vec3d {

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec3dOps.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec3dOps.kt
@@ -19,6 +19,7 @@ package org.quiltmc.qkl.wrapper.minecraft.math
 import net.minecraft.util.math.Vec3d
 import net.minecraft.util.math.Vec3f
 import net.minecraft.util.math.Vec3i
+import net.minecraft.util.math.BlockPos
 import net.minecraft.client.util.math.Vector3d
 
 //region Standard math operators
@@ -121,6 +122,17 @@ public operator fun Vec3d.plus(other: Vec3i): Vec3d {
 }
 
 /**
+ * Adds a [BlockPos] to a [Vec3d].
+ */
+public operator fun Vec3d.plus(other: BlockPos): Vec3d {
+    return Vec3d(
+        this.x + other.x.toDouble(),
+        this.y + other.y.toDouble(),
+        this.z + other.z.toDouble()
+    )
+}
+
+/**
  * Adds a [Vector3d] to a [Vec3d].
  */
 public operator fun Vec3d.plus(other: Vector3d): Vec3d {
@@ -146,6 +158,17 @@ public operator fun Vec3d.minus(other: Vec3f): Vec3d {
  * Subtracts a [Vec3i] from a [Vec3d].
  */
 public operator fun Vec3d.minus(other: Vec3i): Vec3d {
+    return Vec3d(
+        this.x - other.x.toDouble(),
+        this.y - other.y.toDouble(),
+        this.z - other.z.toDouble()
+    )
+}
+
+/**
+ * Subtracts a [BlockPos] from a [Vec3d].
+ */
+public operator fun Vec3d.minus(other: BlockPos): Vec3d {
     return Vec3d(
         this.x - other.x.toDouble(),
         this.y - other.y.toDouble(),
@@ -181,6 +204,18 @@ public operator fun Vec3d.times(other: Vec3f): Vec3d {
  * This method is a shorthand for component wise multiplication.
  */
 public operator fun Vec3d.times(other: Vec3i): Vec3d {
+    return Vec3d(
+        this.x * other.x.toDouble(),
+        this.y * other.y.toDouble(),
+        this.z * other.z.toDouble()
+    )
+}
+
+/**
+ * Multiplies a [Vec3d] and a [BlockPos].
+ * This method is a shorthand for component wise multiplication.
+ */
+public operator fun Vec3d.times(other: BlockPos): Vec3d {
     return Vec3d(
         this.x * other.x.toDouble(),
         this.y * other.y.toDouble(),
@@ -241,6 +276,20 @@ public infix fun Vec3d.dot(other: Vec3i): Double {
  * The cross product of a [Vec3d] and a [Vec3i].
  */
 public infix fun Vec3d.cross(other: Vec3i): Vec3d {
+    return this.crossProduct(Vec3d.of(other))
+}
+
+/**
+ * The dot product of a [Vec3d] and a [BlockPos].
+ */
+public infix fun Vec3d.dot(other: BlockPos): Double {
+    return this.dotProduct(Vec3d.of(other))
+}
+
+/**
+ * The cross product of a [Vec3d] and a [BlockPos].
+ */
+public infix fun Vec3d.cross(other: BlockPos): Vec3d {
     return this.crossProduct(Vec3d.of(other))
 }
 

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec3fOps.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec3fOps.kt
@@ -69,6 +69,17 @@ public operator fun Vec3f.times(other: Float): Vec3f {
 }
 
 /**
+ * Multiplies a Float and a [Vec3f].
+ */
+public operator fun Float.times(other: Vec3f): Vec3f {
+    return Vec3f(
+        this * other.x,
+        this * other.y,
+        this * other.z
+    )
+}
+
+/**
  * Divides a [Vec3f] and a Float.
  */
 public operator fun Vec3f.div(other: Float): Vec3f {

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec3fOps.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec3fOps.kt
@@ -16,7 +16,11 @@
 
 package org.quiltmc.qkl.wrapper.minecraft.math
 
+import net.minecraft.client.util.math.Vector3d
+import net.minecraft.util.math.BlockPos
+import net.minecraft.util.math.Vec3d
 import net.minecraft.util.math.Vec3f
+import net.minecraft.util.math.Vec3i
 
 //region Standard math operators
 /**
@@ -190,5 +194,51 @@ public operator fun Vec3f.component2(): Float {
  */
 public operator fun Vec3f.component3(): Float {
     return this.z
+}
+//endregion
+
+//region Conversion methods
+/**
+ * Converts a [Vec3f] to a [Vec3d].
+ */
+public fun Vec3f.toVec3d(): Vec3d {
+    return Vec3d(
+        this.x.toDouble(),
+        this.y.toDouble(),
+        this.z.toDouble()
+    )
+}
+
+/**
+ * Converts a [Vec3f] to a [Vec3i].
+ */
+public fun Vec3f.toVec3i(): Vec3i {
+    return Vec3i(
+        this.x.toInt(),
+        this.y.toInt(),
+        this.z.toInt()
+    )
+}
+
+/**
+ * Converts a [Vec3f] to a [BlockPos].
+ */
+public fun Vec3f.toBlockPos(): BlockPos {
+    return BlockPos(
+        this.x.toInt(),
+        this.y.toInt(),
+        this.z.toInt()
+    )
+}
+
+/**
+ * Converts a [Vec3f] to a [Vector3d].
+ */
+public fun Vec3f.toVector3d(): Vector3d {
+    return Vector3d(
+        this.x.toDouble(),
+        this.y.toDouble(),
+        this.z.toDouble()
+    )
 }
 //endregion

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec3fOps.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec3fOps.kt
@@ -16,12 +16,7 @@
 
 package org.quiltmc.qkl.wrapper.minecraft.math
 
-import net.minecraft.util.math.Vec3d
 import net.minecraft.util.math.Vec3f
-import net.minecraft.util.math.Vec3i
-import net.minecraft.util.math.BlockPos
-import net.minecraft.client.util.math.Vector3d
-import net.minecraft.util.math.MathHelper.sqrt
 
 //region Standard math operators
 /**
@@ -99,156 +94,7 @@ public operator fun Vec3f.unaryMinus(): Vec3f {
 }
 //endregion
 
-//region Type compatibility operator variations
-/**
- * Adds a [Vec3d] to a [Vec3f].
- */
-public operator fun Vec3f.plus(other: Vec3d): Vec3f {
-    return Vec3f(
-        this.x + other.x.toFloat(),
-        this.y + other.y.toFloat(),
-        this.z + other.z.toFloat()
-    )
-}
-
-/**
- * Adds a [Vec3i] to a [Vec3f].
- */
-public operator fun Vec3f.plus(other: Vec3i): Vec3f {
-    return Vec3f(
-        this.x + other.x.toFloat(),
-        this.y + other.y.toFloat(),
-        this.z + other.z.toFloat()
-    )
-}
-
-/**
- * Adds a [BlockPos] to a [Vec3f].
- */
-public operator fun Vec3f.plus(other: BlockPos): Vec3f {
-    return Vec3f(
-        this.x + other.x.toFloat(),
-        this.y + other.y.toFloat(),
-        this.z + other.z.toFloat()
-    )
-}
-
-/**
- * Adds a [Vector3d] to a [Vec3f].
- */
-public operator fun Vec3f.plus(other: Vector3d): Vec3f {
-    return Vec3f(
-        this.x + other.x.toFloat(),
-        this.y + other.y.toFloat(),
-        this.z + other.z.toFloat()
-    )
-}
-
-/**
- * Subtracts a [Vec3d] from a [Vec3f].
- */
-public operator fun Vec3f.minus(other: Vec3d): Vec3f {
-    return Vec3f(
-        this.x - other.x.toFloat(),
-        this.y - other.y.toFloat(),
-        this.z - other.z.toFloat()
-    )
-}
-
-/**
- * Subtracts a [Vec3i] from a [Vec3f].
- */
-public operator fun Vec3f.minus(other: Vec3i): Vec3f {
-    return Vec3f(
-        this.x - other.x.toFloat(),
-        this.y - other.y.toFloat(),
-        this.z - other.z.toFloat()
-    )
-}
-
-/**
- * Subtracts a [BlockPos] from a [Vec3f].
- */
-public operator fun Vec3f.minus(other: BlockPos): Vec3f {
-    return Vec3f(
-        this.x - other.x.toFloat(),
-        this.y - other.y.toFloat(),
-        this.z - other.z.toFloat()
-    )
-}
-
-/**
- * Subtracts a [Vector3d] from a [Vec3f].
- */
-public operator fun Vec3f.minus(other: Vector3d): Vec3f {
-    return Vec3f(
-        this.x - other.x.toFloat(),
-        this.y - other.y.toFloat(),
-        this.z - other.z.toFloat()
-    )
-}
-
-/**
- * Multiplies a [Vec3f] and a [Vec3d].
- * This method is a shorthand for component wise multiplication.
- */
-public operator fun Vec3f.times(other: Vec3d): Vec3f {
-    return Vec3f(
-        this.x * other.x.toFloat(),
-        this.y * other.y.toFloat(),
-        this.z * other.z.toFloat()
-    )
-}
-
-/**
- * Multiplies a [Vec3f] and a [Vec3i].
- * This method is a shorthand for component wise multiplication.
- */
-public operator fun Vec3f.times(other: Vec3i): Vec3f {
-    return Vec3f(
-        this.x * other.x.toFloat(),
-        this.y * other.y.toFloat(),
-        this.z * other.z.toFloat()
-    )
-}
-
-/**
- * Multiplies a [Vec3f] and a [BlockPos].
- * This method is a shorthand for component wise multiplication.
- */
-public operator fun Vec3f.times(other: BlockPos): Vec3f {
-    return Vec3f(
-        this.x * other.x.toFloat(),
-        this.y * other.y.toFloat(),
-        this.z * other.z.toFloat()
-    )
-}
-
-/**
- * Multiplies a [Vec3f] and a [Vector3d].
- * This method is a shorthand for component wise multiplication.
- */
-public operator fun Vec3f.times(other: Vector3d): Vec3f {
-    return Vec3f(
-        this.x * other.x.toFloat(),
-        this.y * other.y.toFloat(),
-        this.z * other.z.toFloat()
-    )
-}
-//endregion
-
 //region xAssign math operators
-/**
- * Adds a [Vec3d] to a [Vec3f].
- */
-public operator fun Vec3f.plusAssign(other: Vec3d) {
-    this.set(
-        this.x + other.x.toFloat(),
-        this.y + other.y.toFloat(),
-        this.z + other.z.toFloat()
-    )
-}
-
 /**
  * Adds a [Vec3f] to a [Vec3f].
  */
@@ -257,50 +103,6 @@ public operator fun Vec3f.plusAssign(other: Vec3f) {
         this.x + other.x,
         this.y + other.y,
         this.z + other.z
-    )
-}
-
-/**
- * Adds a [Vec3i] to a [Vec3f].
- */
-public operator fun Vec3f.plusAssign(other: Vec3i) {
-    this.set(
-        this.x + other.x.toFloat(),
-        this.y + other.y.toFloat(),
-        this.z + other.z.toFloat()
-    )
-}
-
-/**
- * Adds a [BlockPos] to a [Vec3f].
- */
-public operator fun Vec3f.plusAssign(other: BlockPos) {
-    this.set(
-        this.x + other.x.toFloat(),
-        this.y + other.y.toFloat(),
-        this.z + other.z.toFloat()
-    )
-}
-
-/**
- * Adds a [Vector3d] to a [Vec3f].
- */
-public operator fun Vec3f.plusAssign(other: Vector3d) {
-    this.set(
-        this.x + other.x.toFloat(),
-        this.y + other.y.toFloat(),
-        this.z + other.z.toFloat()
-    )
-}
-
-/**
- * Subtracts a [Vec3d] from a [Vec3f].
- */
-public operator fun Vec3f.minusAssign(other: Vec3d) {
-    this.set(
-        this.x - other.x.toFloat(),
-        this.y - other.y.toFloat(),
-        this.z - other.z.toFloat()
     )
 }
 
@@ -316,51 +118,6 @@ public operator fun Vec3f.minusAssign(other: Vec3f) {
 }
 
 /**
- * Subtracts a [Vec3i] from a [Vec3f].
- */
-public operator fun Vec3f.minusAssign(other: Vec3i) {
-    this.set(
-        this.x - other.x.toFloat(),
-        this.y - other.y.toFloat(),
-        this.z - other.z.toFloat()
-    )
-}
-
-/**
- * Subtracts a [BlockPos] from a [Vec3f].
- */
-public operator fun Vec3f.minusAssign(other: BlockPos) {
-    this.set(
-        this.x - other.x.toFloat(),
-        this.y - other.y.toFloat(),
-        this.z - other.z.toFloat()
-    )
-}
-
-/**
- * Subtracts a [Vector3d] from a [Vec3f].
- */
-public operator fun Vec3f.minusAssign(other: Vector3d) {
-    this.set(
-        this.x - other.x.toFloat(),
-        this.y - other.y.toFloat(),
-        this.z - other.z.toFloat()
-    )
-}
-
-/**
- * Multiplies a [Vec3f] and a [Vec3d].
- * This method is a shorthand for component wise multiplication.
- */
-public operator fun Vec3f.timesAssign(other: Vec3d) {
-    this.set(
-        this.x * other.x.toFloat(),
-        this.y * other.y.toFloat(),
-        this.z * other.z.toFloat()
-    )
-}
-
-/**
  * Multiplies a [Vec3f] and a [Vec3f].
  * This method is a shorthand for component wise multiplication.
  */
@@ -369,42 +126,6 @@ public operator fun Vec3f.timesAssign(other: Vec3f) {
         this.x * other.x,
         this.y * other.y,
         this.z * other.z
-    )
-}
-
-/**
- * Multiplies a [Vec3f] and a [Vec3i].
- * This method is a shorthand for component wise multiplication.
- */
-public operator fun Vec3f.timesAssign(other: Vec3i) {
-    this.set(
-        this.x * other.x.toFloat(),
-        this.y * other.y.toFloat(),
-        this.z * other.z.toFloat()
-    )
-}
-
-/**
- * Multiplies a [Vec3f] and a [BlockPos].
- * This method is a shorthand for component wise multiplication.
- */
-public operator fun Vec3f.timesAssign(other: BlockPos) {
-    this.set(
-        this.x * other.x.toFloat(),
-        this.y * other.y.toFloat(),
-        this.z * other.z.toFloat()
-    )
-}
-
-/**
- * Multiplies a [Vec3f] and a [Vector3d].
- * This method is a shorthand for component wise multiplication.
- */
-public operator fun Vec3f.timesAssign(other: Vector3d) {
-    this.set(
-        this.x * other.x.toFloat(),
-        this.y * other.y.toFloat(),
-        this.z * other.z.toFloat()
     )
 }
 
@@ -433,24 +154,6 @@ public operator fun Vec3f.divAssign(other: Float) {
 
 //region Vector specific operators
 /**
- * The dot product of a [Vec3f] and a [Vec3d].
- */
-public infix fun Vec3f.dot(other: Vec3d): Float {
-    return this.dot(Vec3f(other))
-}
-
-/**
- * The cross product of a [Vec3f] and a [Vec3d].
- */
-public infix fun Vec3f.cross(other: Vec3d): Vec3f {
-    return Vec3f(
-        (this.y * other.z - this.z * other.y).toFloat(),
-        (this.z * other.x - this.x * other.z).toFloat(),
-        (this.x * other.y - this.y * other.x).toFloat()
-    )
-}
-
-/**
  * The dot product of a [Vec3f] and a [Vec3f].
  */
 public infix fun Vec3f.dot(other: Vec3f): Float {
@@ -466,74 +169,6 @@ public infix fun Vec3f.cross(other: Vec3f): Vec3f {
         this.z * other.x - this.x * other.z,
         this.x * other.y - this.y * other.x
     )
-}
-
-/**
- * The dot product of a [Vec3f] and a [Vec3i].
- */
-public infix fun Vec3f.dot(other: Vec3i): Float {
-    return this.dot(Vec3f(other.x.toFloat(), other.y.toFloat(), other.z.toFloat()))
-}
-
-/**
- * The cross product of a [Vec3f] and a [Vec3i].
- */
-public infix fun Vec3f.cross(other: Vec3i): Vec3f {
-    return Vec3f(
-        this.y * other.z - this.z * other.y,
-        this.z * other.x - this.x * other.z,
-        this.x * other.y - this.y * other.x
-    )
-}
-
-/**
- * The dot product of a [Vec3f] and a [BlockPos].
- */
-public infix fun Vec3f.dot(other: BlockPos): Float {
-    return this.dot(Vec3f(other.x.toFloat(), other.y.toFloat(), other.z.toFloat()))
-}
-
-/**
- * The cross product of a [Vec3f] and a [BlockPos].
- */
-public infix fun Vec3f.cross(other: BlockPos): Vec3f {
-    return Vec3f(
-        this.y * other.z - this.z * other.y,
-        this.z * other.x - this.x * other.z,
-        this.x * other.y - this.y * other.x
-    )
-}
-
-/**
- * The dot product of a [Vec3f] and a [Vector3d].
- */
-public infix fun Vec3f.dot(other: Vector3d): Float {
-    return this.dot(Vec3f(other.x.toFloat(), other.y.toFloat(), other.z.toFloat()))
-}
-
-/**
- * The cross product of a [Vec3f] and a [Vector3d].
- */
-public infix fun Vec3f.cross(other: Vector3d): Vec3f {
-    return Vec3f(
-        (this.y * other.z - this.z * other.y).toFloat(),
-        (this.z * other.x - this.x * other.z).toFloat(),
-        (this.x * other.y - this.y * other.x).toFloat()
-    )
-}
-
-/**
- * The length of a [Vec3f].
- */
-public fun Vec3f.length(): Float {
-    return sqrt(x * x + y * y + z * z)
-}
-
-/**
- * The length squared of a [Vec3f].
- */
-public fun Vec3f.lengthSquared(): Float {
-    return x * x + y * y + z * z
 }
 
 /**

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec3fOps.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec3fOps.kt
@@ -19,6 +19,7 @@ package org.quiltmc.qkl.wrapper.minecraft.math
 import net.minecraft.util.math.Vec3d
 import net.minecraft.util.math.Vec3f
 import net.minecraft.util.math.Vec3i
+import net.minecraft.util.math.BlockPos
 import net.minecraft.client.util.math.Vector3d
 import net.minecraft.util.math.MathHelper.sqrt
 
@@ -122,6 +123,17 @@ public operator fun Vec3f.plus(other: Vec3i): Vec3f {
 }
 
 /**
+ * Adds a [BlockPos] to a [Vec3f].
+ */
+public operator fun Vec3f.plus(other: BlockPos): Vec3f {
+    return Vec3f(
+        this.x + other.x.toFloat(),
+        this.y + other.y.toFloat(),
+        this.z + other.z.toFloat()
+    )
+}
+
+/**
  * Adds a [Vector3d] to a [Vec3f].
  */
 public operator fun Vec3f.plus(other: Vector3d): Vec3f {
@@ -147,6 +159,17 @@ public operator fun Vec3f.minus(other: Vec3d): Vec3f {
  * Subtracts a [Vec3i] from a [Vec3f].
  */
 public operator fun Vec3f.minus(other: Vec3i): Vec3f {
+    return Vec3f(
+        this.x - other.x.toFloat(),
+        this.y - other.y.toFloat(),
+        this.z - other.z.toFloat()
+    )
+}
+
+/**
+ * Subtracts a [BlockPos] from a [Vec3f].
+ */
+public operator fun Vec3f.minus(other: BlockPos): Vec3f {
     return Vec3f(
         this.x - other.x.toFloat(),
         this.y - other.y.toFloat(),
@@ -182,6 +205,18 @@ public operator fun Vec3f.times(other: Vec3d): Vec3f {
  * This method is a shorthand for component wise multiplication.
  */
 public operator fun Vec3f.times(other: Vec3i): Vec3f {
+    return Vec3f(
+        this.x * other.x.toFloat(),
+        this.y * other.y.toFloat(),
+        this.z * other.z.toFloat()
+    )
+}
+
+/**
+ * Multiplies a [Vec3f] and a [BlockPos].
+ * This method is a shorthand for component wise multiplication.
+ */
+public operator fun Vec3f.times(other: BlockPos): Vec3f {
     return Vec3f(
         this.x * other.x.toFloat(),
         this.y * other.y.toFloat(),
@@ -237,6 +272,17 @@ public operator fun Vec3f.plusAssign(other: Vec3i) {
 }
 
 /**
+ * Adds a [BlockPos] to a [Vec3f].
+ */
+public operator fun Vec3f.plusAssign(other: BlockPos) {
+    this.set(
+        this.x + other.x.toFloat(),
+        this.y + other.y.toFloat(),
+        this.z + other.z.toFloat()
+    )
+}
+
+/**
  * Adds a [Vector3d] to a [Vec3f].
  */
 public operator fun Vec3f.plusAssign(other: Vector3d) {
@@ -273,6 +319,17 @@ public operator fun Vec3f.minusAssign(other: Vec3f) {
  * Subtracts a [Vec3i] from a [Vec3f].
  */
 public operator fun Vec3f.minusAssign(other: Vec3i) {
+    this.set(
+        this.x - other.x.toFloat(),
+        this.y - other.y.toFloat(),
+        this.z - other.z.toFloat()
+    )
+}
+
+/**
+ * Subtracts a [BlockPos] from a [Vec3f].
+ */
+public operator fun Vec3f.minusAssign(other: BlockPos) {
     this.set(
         this.x - other.x.toFloat(),
         this.y - other.y.toFloat(),
@@ -320,6 +377,18 @@ public operator fun Vec3f.timesAssign(other: Vec3f) {
  * This method is a shorthand for component wise multiplication.
  */
 public operator fun Vec3f.timesAssign(other: Vec3i) {
+    this.set(
+        this.x * other.x.toFloat(),
+        this.y * other.y.toFloat(),
+        this.z * other.z.toFloat()
+    )
+}
+
+/**
+ * Multiplies a [Vec3f] and a [BlockPos].
+ * This method is a shorthand for component wise multiplication.
+ */
+public operator fun Vec3f.timesAssign(other: BlockPos) {
     this.set(
         this.x * other.x.toFloat(),
         this.y * other.y.toFloat(),
@@ -410,6 +479,24 @@ public infix fun Vec3f.dot(other: Vec3i): Float {
  * The cross product of a [Vec3f] and a [Vec3i].
  */
 public infix fun Vec3f.cross(other: Vec3i): Vec3f {
+    return Vec3f(
+        this.y * other.z - this.z * other.y,
+        this.z * other.x - this.x * other.z,
+        this.x * other.y - this.y * other.x
+    )
+}
+
+/**
+ * The dot product of a [Vec3f] and a [BlockPos].
+ */
+public infix fun Vec3f.dot(other: BlockPos): Float {
+    return this.dot(Vec3f(other.x.toFloat(), other.y.toFloat(), other.z.toFloat()))
+}
+
+/**
+ * The cross product of a [Vec3f] and a [BlockPos].
+ */
+public infix fun Vec3f.cross(other: BlockPos): Vec3f {
     return Vec3f(
         this.y * other.z - this.z * other.y,
         this.z * other.x - this.x * other.z,

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec3iOps.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec3iOps.kt
@@ -16,7 +16,10 @@
 
 package org.quiltmc.qkl.wrapper.minecraft.math
 
+import net.minecraft.client.util.math.Vector3d
 import net.minecraft.util.math.BlockPos
+import net.minecraft.util.math.Vec3d
+import net.minecraft.util.math.Vec3f
 import net.minecraft.util.math.Vec3i
 import kotlin.math.sqrt
 
@@ -194,5 +197,51 @@ public operator fun Vec3i.component2(): Int {
  */
 public operator fun Vec3i.component3(): Int {
     return this.z
+}
+//endregion
+
+//region Conversion methods
+/**
+ * Converts a [Vec3i] to a [Vec3d].
+ */
+public fun Vec3i.toVec3d(): Vec3d {
+    return Vec3d(
+        this.x.toDouble(),
+        this.y.toDouble(),
+        this.z.toDouble()
+    )
+}
+
+/**
+ * Converts a [Vec3i] to a [Vec3f].
+ */
+public fun Vec3i.toVec3f(): Vec3f {
+    return Vec3f(
+        this.x.toFloat(),
+        this.y.toFloat(),
+        this.z.toFloat()
+    )
+}
+
+/**
+ * Converts a [Vec3i] to a [BlockPos].
+ */
+public fun Vec3i.toBlockPos(): BlockPos {
+    return BlockPos(
+        this.x,
+        this.y,
+        this.z
+    )
+}
+
+/**
+ * Converts a [Vec3i] to a [Vector3d].
+ */
+public fun Vec3i.toVector3d(): Vector3d {
+    return Vector3d(
+        this.x.toDouble(),
+        this.y.toDouble(),
+        this.z.toDouble()
+    )
 }
 //endregion

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec3iOps.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec3iOps.kt
@@ -69,7 +69,18 @@ public operator fun Vec3i.times(other: Int): Vec3i {
 }
 
 /**
- * Divides a [Vec3i] and a Int.
+ * Multiplies an Int and a [Vec3i].
+ */
+public operator fun Int.times(other: Vec3i): Vec3i {
+    return Vec3i(
+        this * other.x,
+        this * other.y,
+        this * other.z
+    )
+}
+
+/**
+ * Divides a [Vec3i] and an Int.
  */
 public operator fun Vec3i.div(other: Int): Vec3i {
     return Vec3i(

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec3iOps.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec3iOps.kt
@@ -19,6 +19,7 @@ package org.quiltmc.qkl.wrapper.minecraft.math
 import net.minecraft.util.math.Vec3d
 import net.minecraft.util.math.Vec3f
 import net.minecraft.util.math.Vec3i
+import net.minecraft.util.math.BlockPos
 import net.minecraft.client.util.math.Vector3d
 import kotlin.math.sqrt
 
@@ -122,6 +123,17 @@ public operator fun Vec3i.plus(other: Vec3f): Vec3i {
 }
 
 /**
+ * Adds a [BlockPos] to a [Vec3i].
+ */
+public operator fun Vec3i.plus(other: BlockPos): Vec3i {
+    return Vec3i(
+        this.x + other.x,
+        this.y + other.y,
+        this.z + other.z
+    )
+}
+
+/**
  * Adds a [Vector3d] to a [Vec3i].
  */
 public operator fun Vec3i.plus(other: Vector3d): Vec3i {
@@ -151,6 +163,17 @@ public operator fun Vec3i.minus(other: Vec3f): Vec3i {
         this.x - other.x.toInt(),
         this.y - other.y.toInt(),
         this.z - other.z.toInt()
+    )
+}
+
+/**
+ * Subtracts a [BlockPos] from a [Vec3i].
+ */
+public operator fun Vec3i.minus(other: BlockPos): Vec3i {
+    return Vec3i(
+        this.x - other.x,
+        this.y - other.y,
+        this.z - other.z
     )
 }
 
@@ -186,6 +209,18 @@ public operator fun Vec3i.times(other: Vec3f): Vec3i {
         this.x * other.x.toInt(),
         this.y * other.y.toInt(),
         this.z * other.z.toInt()
+    )
+}
+
+/**
+ * Multiplies a [Vec3i] and a [BlockPos].
+ * This method is a shorthand for component wise multiplication.
+ */
+public operator fun Vec3i.times(other: BlockPos): Vec3i {
+    return Vec3i(
+        this.x * other.x,
+        this.y * other.y,
+        this.z * other.z
     )
 }
 
@@ -242,6 +277,20 @@ public infix fun Vec3i.dot(other: Vec3i): Int {
  * The cross product of a [Vec3i] and a [Vec3i].
  */
 public infix fun Vec3i.cross(other: Vec3i): Vec3i {
+    return this.crossProduct(other)
+}
+
+/**
+ * The dot product of a [Vec3i] and a [BlockPos].
+ */
+public infix fun Vec3i.dot(other: BlockPos): Int {
+    return this.x * other.x + this.y * other.y + this.z * other.z
+}
+
+/**
+ * The cross product of a [Vec3i] and a [BlockPos].
+ */
+public infix fun Vec3i.cross(other: BlockPos): Vec3i {
     return this.crossProduct(other)
 }
 

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec3iOps.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vec3iOps.kt
@@ -16,11 +16,8 @@
 
 package org.quiltmc.qkl.wrapper.minecraft.math
 
-import net.minecraft.util.math.Vec3d
-import net.minecraft.util.math.Vec3f
-import net.minecraft.util.math.Vec3i
 import net.minecraft.util.math.BlockPos
-import net.minecraft.client.util.math.Vector3d
+import net.minecraft.util.math.Vec3i
 import kotlin.math.sqrt
 
 //region Standard math operators
@@ -101,28 +98,6 @@ public operator fun Vec3i.unaryMinus(): Vec3i {
 
 //region Type compatibility operator variations
 /**
- * Adds a [Vec3d] to a [Vec3i].
- */
-public operator fun Vec3i.plus(other: Vec3d): Vec3i {
-    return Vec3i(
-        this.x + other.x.toInt(),
-        this.y + other.y.toInt(),
-        this.z + other.z.toInt()
-    )
-}
-
-/**
- * Adds a [Vec3f] to a [Vec3i].
- */
-public operator fun Vec3i.plus(other: Vec3f): Vec3i {
-    return Vec3i(
-        this.x + other.x.toInt(),
-        this.y + other.y.toInt(),
-        this.z + other.z.toInt()
-    )
-}
-
-/**
  * Adds a [BlockPos] to a [Vec3i].
  */
 public operator fun Vec3i.plus(other: BlockPos): Vec3i {
@@ -130,39 +105,6 @@ public operator fun Vec3i.plus(other: BlockPos): Vec3i {
         this.x + other.x,
         this.y + other.y,
         this.z + other.z
-    )
-}
-
-/**
- * Adds a [Vector3d] to a [Vec3i].
- */
-public operator fun Vec3i.plus(other: Vector3d): Vec3i {
-    return Vec3i(
-        this.x + other.x.toInt(),
-        this.y + other.y.toInt(),
-        this.z + other.z.toInt()
-    )
-}
-
-/**
- * Subtracts a [Vec3d] from a [Vec3i].
- */
-public operator fun Vec3i.minus(other: Vec3d): Vec3i {
-    return Vec3i(
-        this.x - other.x.toInt(),
-        this.y - other.y.toInt(),
-        this.z - other.z.toInt()
-    )
-}
-
-/**
- * Subtracts a [Vec3f] from a [Vec3i].
- */
-public operator fun Vec3i.minus(other: Vec3f): Vec3i {
-    return Vec3i(
-        this.x - other.x.toInt(),
-        this.y - other.y.toInt(),
-        this.z - other.z.toInt()
     )
 }
 
@@ -178,41 +120,6 @@ public operator fun Vec3i.minus(other: BlockPos): Vec3i {
 }
 
 /**
- * Subtracts a [Vector3d] from a [Vec3i].
- */
-public operator fun Vec3i.minus(other: Vector3d): Vec3i {
-    return Vec3i(
-        this.x - other.x.toInt(),
-        this.y - other.y.toInt(),
-        this.z - other.z.toInt()
-    )
-}
-
-/**
- * Multiplies a [Vec3i] and a [Vec3d].
- * This method is a shorthand for component wise multiplication.
- */
-public operator fun Vec3i.times(other: Vec3d): Vec3i {
-    return Vec3i(
-        this.x * other.x.toInt(),
-        this.y * other.y.toInt(),
-        this.z * other.z.toInt()
-    )
-}
-
-/**
- * Multiplies a [Vec3i] and a [Vec3f].
- * This method is a shorthand for component wise multiplication.
- */
-public operator fun Vec3i.times(other: Vec3f): Vec3i {
-    return Vec3i(
-        this.x * other.x.toInt(),
-        this.y * other.y.toInt(),
-        this.z * other.z.toInt()
-    )
-}
-
-/**
  * Multiplies a [Vec3i] and a [BlockPos].
  * This method is a shorthand for component wise multiplication.
  */
@@ -223,49 +130,9 @@ public operator fun Vec3i.times(other: BlockPos): Vec3i {
         this.z * other.z
     )
 }
-
-/**
- * Multiplies a [Vec3i] and a [Vector3d].
- * This method is a shorthand for component wise multiplication.
- */
-public operator fun Vec3i.times(other: Vector3d): Vec3i {
-    return Vec3i(
-        this.x * other.x.toInt(),
-        this.y * other.y.toInt(),
-        this.z * other.z.toInt()
-    )
-}
 //endregion
 
 //region Vector specific operators
-/**
- * The dot product of a [Vec3i] and a [Vec3d].
- */
-public infix fun Vec3i.dot(other: Vec3d): Int {
-    return this.x * other.x.toInt() + this.y * other.y.toInt() + this.z * other.z.toInt()
-}
-
-/**
- * The cross product of a [Vec3i] and a [Vec3d].
- */
-public infix fun Vec3i.cross(other: Vec3d): Vec3i {
-    return this.crossProduct(Vec3i(other.x, other.y, other.z))
-}
-
-/**
- * The dot product of a [Vec3i] and a [Vec3f].
- */
-public infix fun Vec3i.dot(other: Vec3f): Int {
-    return this.x * other.x.toInt() + this.y * other.y.toInt() + this.z * other.z.toInt()
-}
-
-/**
- * The cross product of a [Vec3i] and a [Vec3f].
- */
-public infix fun Vec3i.cross(other: Vec3f): Vec3i {
-    return this.crossProduct(Vec3i(other.x.toDouble(), other.y.toDouble(), other.z.toDouble()))
-}
-
 /**
  * The dot product of a [Vec3i] and a [Vec3i].
  */
@@ -292,20 +159,6 @@ public infix fun Vec3i.dot(other: BlockPos): Int {
  */
 public infix fun Vec3i.cross(other: BlockPos): Vec3i {
     return this.crossProduct(other)
-}
-
-/**
- * The dot product of a [Vec3i] and a [Vector3d].
- */
-public infix fun Vec3i.dot(other: Vector3d): Int {
-    return this.x * other.x.toInt() + this.y * other.y.toInt() + this.z * other.z.toInt()
-}
-
-/**
- * The cross product of a [Vec3i] and a [Vector3d].
- */
-public infix fun Vec3i.cross(other: Vector3d): Vec3i {
-    return this.crossProduct(Vec3i(other.x, other.y, other.z))
 }
 
 /**

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vector2fOps.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vector2fOps.kt
@@ -63,6 +63,16 @@ public operator fun Vector2f.times(other: Float): Vector2f {
 }
 
 /**
+ * Multiplies a Float and a [Vector2f].
+ */
+public operator fun Float.times(other: Vector2f): Vector2f {
+    return Vector2f(
+        this * other.x,
+        this * other.y
+    )
+}
+
+/**
  * Divides a [Vector2f] and a Float.
  */
 public operator fun Vector2f.div(other: Float): Vector2f {

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vector2fOps.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vector2fOps.kt
@@ -178,3 +178,15 @@ public operator fun Vector2f.component2(): Float {
     return this.y
 }
 //endregion
+
+//region Conversion methods
+/**
+ * Converts a [Vector2f] to a [Vec2f].
+ */
+public fun Vector2f.toVec2f(): Vec2f {
+    return Vec2f(
+        this.x,
+        this.y
+    )
+}
+//endregion

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vector3dOps.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vector3dOps.kt
@@ -19,6 +19,7 @@ package org.quiltmc.qkl.wrapper.minecraft.math
 import net.minecraft.util.math.Vec3d
 import net.minecraft.util.math.Vec3f
 import net.minecraft.util.math.Vec3i
+import net.minecraft.util.math.BlockPos
 import net.minecraft.client.util.math.Vector3d
 import kotlin.math.sqrt
 
@@ -133,6 +134,17 @@ public operator fun Vector3d.plus(other: Vec3i): Vector3d {
 }
 
 /**
+ * Adds a [BlockPos] to a [Vector3d].
+ */
+public operator fun Vector3d.plus(other: BlockPos): Vector3d {
+    return Vector3d(
+        this.x + other.x.toDouble(),
+        this.y + other.y.toDouble(),
+        this.z + other.z.toDouble()
+    )
+}
+
+/**
  * Subtracts a [Vec3d] from a [Vector3d].
  */
 public operator fun Vector3d.minus(other: Vec3d): Vector3d {
@@ -158,6 +170,17 @@ public operator fun Vector3d.minus(other: Vec3f): Vector3d {
  * Subtracts a [Vec3i] from a [Vector3d].
  */
 public operator fun Vector3d.minus(other: Vec3i): Vector3d {
+    return Vector3d(
+        this.x - other.x.toDouble(),
+        this.y - other.y.toDouble(),
+        this.z - other.z.toDouble()
+    )
+}
+
+/**
+ * Subtracts a [BlockPos] from a [Vector3d].
+ */
+public operator fun Vector3d.minus(other: BlockPos): Vector3d {
     return Vector3d(
         this.x - other.x.toDouble(),
         this.y - other.y.toDouble(),
@@ -200,6 +223,18 @@ public operator fun Vector3d.times(other: Vec3i): Vector3d {
         this.z * other.z.toDouble()
     )
 }
+
+/**
+ * Multiplies a [Vector3d] and a [BlockPos].
+ * This method is a shorthand for component wise multiplication.
+ */
+public operator fun Vector3d.times(other: BlockPos): Vector3d {
+    return Vector3d(
+        this.x * other.x.toDouble(),
+        this.y * other.y.toDouble(),
+        this.z * other.z.toDouble()
+    )
+}
 //endregion
 
 //region xAssign math operators
@@ -225,6 +260,15 @@ public operator fun Vector3d.plusAssign(other: Vec3f) {
  * Adds a [Vec3i] to a [Vector3d].
  */
 public operator fun Vector3d.plusAssign(other: Vec3i) {
+    this.x = this.x + other.x.toDouble()
+    this.y = this.y + other.y.toDouble()
+    this.z = this.z + other.z.toDouble()
+}
+
+/**
+ * Adds a [BlockPos] to a [Vector3d].
+ */
+public operator fun Vector3d.plusAssign(other: BlockPos) {
     this.x = this.x + other.x.toDouble()
     this.y = this.y + other.y.toDouble()
     this.z = this.z + other.z.toDouble()
@@ -267,6 +311,15 @@ public operator fun Vector3d.minusAssign(other: Vec3i) {
 }
 
 /**
+ * Subtracts a [BlockPos] from a [Vector3d].
+ */
+public operator fun Vector3d.minusAssign(other: BlockPos) {
+    this.x = this.x - other.x.toDouble()
+    this.y = this.y - other.y.toDouble()
+    this.z = this.z - other.z.toDouble()
+}
+
+/**
  * Subtracts a [Vector3d] from a [Vector3d].
  */
 public operator fun Vector3d.minusAssign(other: Vector3d) {
@@ -300,6 +353,16 @@ public operator fun Vector3d.timesAssign(other: Vec3f) {
  * This method is a shorthand for component wise multiplication.
  */
 public operator fun Vector3d.timesAssign(other: Vec3i) {
+    this.x = this.x * other.x.toDouble()
+    this.y = this.y * other.y.toDouble()
+    this.z = this.z * other.z.toDouble()
+}
+
+/**
+ * Multiplies a [Vector3d] and a [BlockPos].
+ * This method is a shorthand for component wise multiplication.
+ */
+public operator fun Vector3d.timesAssign(other: BlockPos) {
     this.x = this.x * other.x.toDouble()
     this.y = this.y * other.y.toDouble()
     this.z = this.z * other.z.toDouble()
@@ -382,6 +445,24 @@ public infix fun Vector3d.dot(other: Vec3i): Double {
  * The cross product of a [Vector3d] and a [Vec3i].
  */
 public infix fun Vector3d.cross(other: Vec3i): Vector3d {
+    return Vector3d(
+        this.y * other.z - this.z * other.y,
+        this.z * other.x - this.x * other.z,
+        this.x * other.y - this.y * other.x
+    )
+}
+
+/**
+ * The dot product of a [Vector3d] and a [BlockPos].
+ */
+public infix fun Vector3d.dot(other: BlockPos): Double {
+    return this.x * other.x + this.y * other.y + this.z * other.z
+}
+
+/**
+ * The cross product of a [Vector3d] and a [BlockPos].
+ */
+public infix fun Vector3d.cross(other: BlockPos): Vector3d {
     return Vector3d(
         this.y * other.z - this.z * other.y,
         this.z * other.x - this.x * other.z,

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vector3dOps.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vector3dOps.kt
@@ -69,6 +69,17 @@ public operator fun Vector3d.times(other: Double): Vector3d {
 }
 
 /**
+ * Multiplies a Double and a [Vector3d].
+ */
+public operator fun Double.times(other: Vector3d): Vector3d {
+    return Vector3d(
+        this * other.x,
+        this * other.y,
+        this * other.z
+    )
+}
+
+/**
  * Divides a [Vector3d] and a Double.
  */
 public operator fun Vector3d.div(other: Double): Vector3d {

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vector3dOps.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vector3dOps.kt
@@ -16,11 +16,8 @@
 
 package org.quiltmc.qkl.wrapper.minecraft.math
 
-import net.minecraft.util.math.Vec3d
-import net.minecraft.util.math.Vec3f
-import net.minecraft.util.math.Vec3i
-import net.minecraft.util.math.BlockPos
 import net.minecraft.client.util.math.Vector3d
+import net.minecraft.util.math.Vec3d
 import kotlin.math.sqrt
 
 //region Standard math operators
@@ -112,39 +109,6 @@ public operator fun Vector3d.plus(other: Vec3d): Vector3d {
 }
 
 /**
- * Adds a [Vec3f] to a [Vector3d].
- */
-public operator fun Vector3d.plus(other: Vec3f): Vector3d {
-    return Vector3d(
-        this.x + other.x.toDouble(),
-        this.y + other.y.toDouble(),
-        this.z + other.z.toDouble()
-    )
-}
-
-/**
- * Adds a [Vec3i] to a [Vector3d].
- */
-public operator fun Vector3d.plus(other: Vec3i): Vector3d {
-    return Vector3d(
-        this.x + other.x.toDouble(),
-        this.y + other.y.toDouble(),
-        this.z + other.z.toDouble()
-    )
-}
-
-/**
- * Adds a [BlockPos] to a [Vector3d].
- */
-public operator fun Vector3d.plus(other: BlockPos): Vector3d {
-    return Vector3d(
-        this.x + other.x.toDouble(),
-        this.y + other.y.toDouble(),
-        this.z + other.z.toDouble()
-    )
-}
-
-/**
  * Subtracts a [Vec3d] from a [Vector3d].
  */
 public operator fun Vector3d.minus(other: Vec3d): Vector3d {
@@ -152,39 +116,6 @@ public operator fun Vector3d.minus(other: Vec3d): Vector3d {
         this.x - other.x,
         this.y - other.y,
         this.z - other.z
-    )
-}
-
-/**
- * Subtracts a [Vec3f] from a [Vector3d].
- */
-public operator fun Vector3d.minus(other: Vec3f): Vector3d {
-    return Vector3d(
-        this.x - other.x.toDouble(),
-        this.y - other.y.toDouble(),
-        this.z - other.z.toDouble()
-    )
-}
-
-/**
- * Subtracts a [Vec3i] from a [Vector3d].
- */
-public operator fun Vector3d.minus(other: Vec3i): Vector3d {
-    return Vector3d(
-        this.x - other.x.toDouble(),
-        this.y - other.y.toDouble(),
-        this.z - other.z.toDouble()
-    )
-}
-
-/**
- * Subtracts a [BlockPos] from a [Vector3d].
- */
-public operator fun Vector3d.minus(other: BlockPos): Vector3d {
-    return Vector3d(
-        this.x - other.x.toDouble(),
-        this.y - other.y.toDouble(),
-        this.z - other.z.toDouble()
     )
 }
 
@@ -199,42 +130,6 @@ public operator fun Vector3d.times(other: Vec3d): Vector3d {
         this.z * other.z
     )
 }
-
-/**
- * Multiplies a [Vector3d] and a [Vec3f].
- * This method is a shorthand for component wise multiplication.
- */
-public operator fun Vector3d.times(other: Vec3f): Vector3d {
-    return Vector3d(
-        this.x * other.x.toDouble(),
-        this.y * other.y.toDouble(),
-        this.z * other.z.toDouble()
-    )
-}
-
-/**
- * Multiplies a [Vector3d] and a [Vec3i].
- * This method is a shorthand for component wise multiplication.
- */
-public operator fun Vector3d.times(other: Vec3i): Vector3d {
-    return Vector3d(
-        this.x * other.x.toDouble(),
-        this.y * other.y.toDouble(),
-        this.z * other.z.toDouble()
-    )
-}
-
-/**
- * Multiplies a [Vector3d] and a [BlockPos].
- * This method is a shorthand for component wise multiplication.
- */
-public operator fun Vector3d.times(other: BlockPos): Vector3d {
-    return Vector3d(
-        this.x * other.x.toDouble(),
-        this.y * other.y.toDouble(),
-        this.z * other.z.toDouble()
-    )
-}
 //endregion
 
 //region xAssign math operators
@@ -245,33 +140,6 @@ public operator fun Vector3d.plusAssign(other: Vec3d) {
     this.x = this.x + other.x
     this.y = this.y + other.y
     this.z = this.z + other.z
-}
-
-/**
- * Adds a [Vec3f] to a [Vector3d].
- */
-public operator fun Vector3d.plusAssign(other: Vec3f) {
-    this.x = this.x + other.x.toDouble()
-    this.y = this.y + other.y.toDouble()
-    this.z = this.z + other.z.toDouble()
-}
-
-/**
- * Adds a [Vec3i] to a [Vector3d].
- */
-public operator fun Vector3d.plusAssign(other: Vec3i) {
-    this.x = this.x + other.x.toDouble()
-    this.y = this.y + other.y.toDouble()
-    this.z = this.z + other.z.toDouble()
-}
-
-/**
- * Adds a [BlockPos] to a [Vector3d].
- */
-public operator fun Vector3d.plusAssign(other: BlockPos) {
-    this.x = this.x + other.x.toDouble()
-    this.y = this.y + other.y.toDouble()
-    this.z = this.z + other.z.toDouble()
 }
 
 /**
@@ -293,33 +161,6 @@ public operator fun Vector3d.minusAssign(other: Vec3d) {
 }
 
 /**
- * Subtracts a [Vec3f] from a [Vector3d].
- */
-public operator fun Vector3d.minusAssign(other: Vec3f) {
-    this.x = this.x - other.x.toDouble()
-    this.y = this.y - other.y.toDouble()
-    this.z = this.z - other.z.toDouble()
-}
-
-/**
- * Subtracts a [Vec3i] from a [Vector3d].
- */
-public operator fun Vector3d.minusAssign(other: Vec3i) {
-    this.x = this.x - other.x.toDouble()
-    this.y = this.y - other.y.toDouble()
-    this.z = this.z - other.z.toDouble()
-}
-
-/**
- * Subtracts a [BlockPos] from a [Vector3d].
- */
-public operator fun Vector3d.minusAssign(other: BlockPos) {
-    this.x = this.x - other.x.toDouble()
-    this.y = this.y - other.y.toDouble()
-    this.z = this.z - other.z.toDouble()
-}
-
-/**
  * Subtracts a [Vector3d] from a [Vector3d].
  */
 public operator fun Vector3d.minusAssign(other: Vector3d) {
@@ -336,36 +177,6 @@ public operator fun Vector3d.timesAssign(other: Vec3d) {
     this.x = this.x * other.x
     this.y = this.y * other.y
     this.z = this.z * other.z
-}
-
-/**
- * Multiplies a [Vector3d] and a [Vec3f].
- * This method is a shorthand for component wise multiplication.
- */
-public operator fun Vector3d.timesAssign(other: Vec3f) {
-    this.x = this.x * other.x.toDouble()
-    this.y = this.y * other.y.toDouble()
-    this.z = this.z * other.z.toDouble()
-}
-
-/**
- * Multiplies a [Vector3d] and a [Vec3i].
- * This method is a shorthand for component wise multiplication.
- */
-public operator fun Vector3d.timesAssign(other: Vec3i) {
-    this.x = this.x * other.x.toDouble()
-    this.y = this.y * other.y.toDouble()
-    this.z = this.z * other.z.toDouble()
-}
-
-/**
- * Multiplies a [Vector3d] and a [BlockPos].
- * This method is a shorthand for component wise multiplication.
- */
-public operator fun Vector3d.timesAssign(other: BlockPos) {
-    this.x = this.x * other.x.toDouble()
-    this.y = this.y * other.y.toDouble()
-    this.z = this.z * other.z.toDouble()
 }
 
 /**
@@ -409,60 +220,6 @@ public infix fun Vector3d.dot(other: Vec3d): Double {
  * The cross product of a [Vector3d] and a [Vec3d].
  */
 public infix fun Vector3d.cross(other: Vec3d): Vector3d {
-    return Vector3d(
-        this.y * other.z - this.z * other.y,
-        this.z * other.x - this.x * other.z,
-        this.x * other.y - this.y * other.x
-    )
-}
-
-/**
- * The dot product of a [Vector3d] and a [Vec3f].
- */
-public infix fun Vector3d.dot(other: Vec3f): Double {
-    return this.x * other.x + this.y * other.y + this.z * other.z
-}
-
-/**
- * The cross product of a [Vector3d] and a [Vec3f].
- */
-public infix fun Vector3d.cross(other: Vec3f): Vector3d {
-    return Vector3d(
-        this.y * other.z - this.z * other.y,
-        this.z * other.x - this.x * other.z,
-        this.x * other.y - this.y * other.x
-    )
-}
-
-/**
- * The dot product of a [Vector3d] and a [Vec3i].
- */
-public infix fun Vector3d.dot(other: Vec3i): Double {
-    return this.x * other.x + this.y * other.y + this.z * other.z
-}
-
-/**
- * The cross product of a [Vector3d] and a [Vec3i].
- */
-public infix fun Vector3d.cross(other: Vec3i): Vector3d {
-    return Vector3d(
-        this.y * other.z - this.z * other.y,
-        this.z * other.x - this.x * other.z,
-        this.x * other.y - this.y * other.x
-    )
-}
-
-/**
- * The dot product of a [Vector3d] and a [BlockPos].
- */
-public infix fun Vector3d.dot(other: BlockPos): Double {
-    return this.x * other.x + this.y * other.y + this.z * other.z
-}
-
-/**
- * The cross product of a [Vector3d] and a [BlockPos].
- */
-public infix fun Vector3d.cross(other: BlockPos): Vector3d {
     return Vector3d(
         this.y * other.z - this.z * other.y,
         this.z * other.x - this.x * other.z,

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vector3dOps.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vector3dOps.kt
@@ -17,7 +17,10 @@
 package org.quiltmc.qkl.wrapper.minecraft.math
 
 import net.minecraft.client.util.math.Vector3d
+import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Vec3d
+import net.minecraft.util.math.Vec3f
+import net.minecraft.util.math.Vec3i
 import kotlin.math.sqrt
 
 //region Standard math operators
@@ -290,5 +293,51 @@ public operator fun Vector3d.component2(): Double {
  */
 public operator fun Vector3d.component3(): Double {
     return this.z
+}
+//endregion
+
+//region Conversion methods
+/**
+ * Converts a [Vector3d] to a [Vec3d].
+ */
+public fun Vector3d.toVec3d(): Vec3d {
+    return Vec3d(
+        this.x,
+        this.y,
+        this.z
+    )
+}
+
+/**
+ * Converts a [Vector3d] to a [Vec3f].
+ */
+public fun Vector3d.toVec3f(): Vec3f {
+    return Vec3f(
+        this.x.toFloat(),
+        this.y.toFloat(),
+        this.z.toFloat()
+    )
+}
+
+/**
+ * Converts a [Vector3d] to a [Vec3i].
+ */
+public fun Vector3d.toVec3i(): Vec3i {
+    return Vec3i(
+        this.x.toInt(),
+        this.y.toInt(),
+        this.z.toInt()
+    )
+}
+
+/**
+ * Converts a [Vector3d] to a [BlockPos].
+ */
+public fun Vector3d.toBlockPos(): BlockPos {
+    return BlockPos(
+        this.x.toInt(),
+        this.y.toInt(),
+        this.z.toInt()
+    )
 }
 //endregion

--- a/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vector4fOps.kt
+++ b/wrapper/minecraft/src/main/kotlin/org/quiltmc/qkl/wrapper/minecraft/math/Vector4fOps.kt
@@ -70,6 +70,18 @@ public operator fun Vector4f.times(other: Float): Vector4f {
 }
 
 /**
+ * Multiplies a Float and a [Vector4f].
+ */
+public operator fun Float.times(other: Vector4f): Vector4f {
+    return Vector4f(
+        this * other.x,
+        this * other.y,
+        this * other.z,
+        this * other.w
+    )
+}
+
+/**
  * Divides a [Vector4f] and a Float.
  */
 public operator fun Vector4f.div(other: Float): Vector4f {


### PR DESCRIPTION
- Adds `scalar * vector` operators
- Adds some basic matrix operations
- Adds BlockPos specific operators (to prevent lowering the type to a Vec3i when doing operations)
- Removes operators on non-same types (No more `Vec3i op Vec3d`) to bring more in line with standard kotlin design
- Adds conversion operators between vectors

College is fast approaching so I decided to get this PRd now before it ends up sitting for a few months, I wouldve liked to add more matrix operators but thats about it.