### PR TITLE
Kotlin serialization based networking

### DIFF
--- a/library/api/library.api
+++ b/library/api/library.api
@@ -796,6 +796,79 @@ public final class org/quiltmc/qkl/library/networking/ServerEventsKt {
 	public static final fun onPlayReady (Lorg/quiltmc/qkl/library/EventRegistration;Lkotlin/jvm/functions/Function3;)V
 }
 
+public final class org/quiltmc/qkl/library/networking/serialization/PacketByteBufDecoder : kotlinx/serialization/encoding/AbstractDecoder {
+	public fun <init> (Lnet/minecraft/network/PacketByteBuf;Lkotlinx/serialization/modules/SerializersModule;)V
+	public synthetic fun <init> (Lnet/minecraft/network/PacketByteBuf;Lkotlinx/serialization/modules/SerializersModule;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun decodeBoolean ()Z
+	public fun decodeByte ()B
+	public fun decodeChar ()C
+	public fun decodeCollectionSize (Lkotlinx/serialization/descriptors/SerialDescriptor;)I
+	public fun decodeDouble ()D
+	public fun decodeElementIndex (Lkotlinx/serialization/descriptors/SerialDescriptor;)I
+	public fun decodeEnum (Lkotlinx/serialization/descriptors/SerialDescriptor;)I
+	public fun decodeFloat ()F
+	public fun decodeInt ()I
+	public fun decodeLong ()J
+	public fun decodeNotNullMark ()Z
+	public fun decodeSequentially ()Z
+	public fun decodeSerializableValue (Lkotlinx/serialization/DeserializationStrategy;)Ljava/lang/Object;
+	public fun decodeShort ()S
+	public fun decodeString ()Ljava/lang/String;
+	public final fun getInput ()Lnet/minecraft/network/PacketByteBuf;
+	public fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
+}
+
+public final class org/quiltmc/qkl/library/networking/serialization/PacketByteBufEncoder : kotlinx/serialization/encoding/AbstractEncoder {
+	public fun <init> ()V
+	public fun <init> (Lkotlinx/serialization/modules/SerializersModule;)V
+	public synthetic fun <init> (Lkotlinx/serialization/modules/SerializersModule;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun beginCollection (Lkotlinx/serialization/descriptors/SerialDescriptor;I)Lkotlinx/serialization/encoding/CompositeEncoder;
+	public fun encodeBoolean (Z)V
+	public fun encodeByte (B)V
+	public fun encodeChar (C)V
+	public fun encodeDouble (D)V
+	public fun encodeEnum (Lkotlinx/serialization/descriptors/SerialDescriptor;I)V
+	public fun encodeFloat (F)V
+	public fun encodeInt (I)V
+	public fun encodeLong (J)V
+	public fun encodeNotNullMark ()V
+	public fun encodeNull ()V
+	public fun encodeSerializableValue (Lkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V
+	public fun encodeShort (S)V
+	public fun encodeString (Ljava/lang/String;)V
+	public final fun getPacketByteBuf ()Lnet/minecraft/network/PacketByteBuf;
+	public fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
+	public final fun setPacketByteBuf (Lnet/minecraft/network/PacketByteBuf;)V
+}
+
+public final class org/quiltmc/qkl/library/networking/serialization/SerializedClientPlayNetworking {
+	public static final field INSTANCE Lorg/quiltmc/qkl/library/networking/serialization/SerializedClientPlayNetworking;
+}
+
+public final class org/quiltmc/qkl/library/networking/serialization/SerializedPacketRegistration {
+	public fun <init> (Lnet/minecraft/util/Identifier;Lorg/quiltmc/qkl/library/networking/serialization/SerializedPacketRegistration$Direction;)V
+	public final fun getDirection ()Lorg/quiltmc/qkl/library/networking/serialization/SerializedPacketRegistration$Direction;
+	public final fun getId ()Lnet/minecraft/util/Identifier;
+	public final fun getOnClientReceiveAction ()Lkotlin/jvm/functions/Function4;
+	public final fun getOnServerReceiveAction ()Lkotlin/jvm/functions/Function5;
+	public final fun onClientReceive (Lkotlin/jvm/functions/Function4;)V
+	public final fun onServerReceive (Lkotlin/jvm/functions/Function5;)V
+	public final fun setOnClientReceiveAction (Lkotlin/jvm/functions/Function4;)V
+	public final fun setOnServerReceiveAction (Lkotlin/jvm/functions/Function5;)V
+}
+
+public final class org/quiltmc/qkl/library/networking/serialization/SerializedPacketRegistration$Direction : java/lang/Enum {
+	public static final field BiDirectional Lorg/quiltmc/qkl/library/networking/serialization/SerializedPacketRegistration$Direction;
+	public static final field ClientToServer Lorg/quiltmc/qkl/library/networking/serialization/SerializedPacketRegistration$Direction;
+	public static final field ServerToClient Lorg/quiltmc/qkl/library/networking/serialization/SerializedPacketRegistration$Direction;
+	public static fun valueOf (Ljava/lang/String;)Lorg/quiltmc/qkl/library/networking/serialization/SerializedPacketRegistration$Direction;
+	public static fun values ()[Lorg/quiltmc/qkl/library/networking/serialization/SerializedPacketRegistration$Direction;
+}
+
+public final class org/quiltmc/qkl/library/networking/serialization/SerializedServerPlayNetworking {
+	public static final field INSTANCE Lorg/quiltmc/qkl/library/networking/serialization/SerializedServerPlayNetworking;
+}
+
 public final class org/quiltmc/qkl/library/recipe/RecipeEventsKt {
 	public static final fun onAddRecipes (Lorg/quiltmc/qkl/library/EventRegistration;Lkotlin/jvm/functions/Function1;)V
 	public static final fun onModifyRecipes (Lorg/quiltmc/qkl/library/EventRegistration;Lkotlin/jvm/functions/Function1;)V

--- a/library/api/library.api
+++ b/library/api/library.api
@@ -797,6 +797,7 @@ public final class org/quiltmc/qkl/library/networking/ServerEventsKt {
 }
 
 public final class org/quiltmc/qkl/library/networking/serialization/PacketByteBufDecoder : kotlinx/serialization/encoding/AbstractDecoder {
+	public static final field Companion Lorg/quiltmc/qkl/library/networking/serialization/PacketByteBufDecoder$Companion;
 	public fun <init> (Lnet/minecraft/network/PacketByteBuf;Lkotlinx/serialization/modules/SerializersModule;)V
 	public synthetic fun <init> (Lnet/minecraft/network/PacketByteBuf;Lkotlinx/serialization/modules/SerializersModule;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun decodeBoolean ()Z
@@ -818,7 +819,11 @@ public final class org/quiltmc/qkl/library/networking/serialization/PacketByteBu
 	public fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
 }
 
+public final class org/quiltmc/qkl/library/networking/serialization/PacketByteBufDecoder$Companion {
+}
+
 public final class org/quiltmc/qkl/library/networking/serialization/PacketByteBufEncoder : kotlinx/serialization/encoding/AbstractEncoder {
+	public static final field Companion Lorg/quiltmc/qkl/library/networking/serialization/PacketByteBufEncoder$Companion;
 	public fun <init> ()V
 	public fun <init> (Lkotlinx/serialization/modules/SerializersModule;)V
 	public synthetic fun <init> (Lkotlinx/serialization/modules/SerializersModule;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -841,16 +846,20 @@ public final class org/quiltmc/qkl/library/networking/serialization/PacketByteBu
 	public final fun setPacketByteBuf (Lnet/minecraft/network/PacketByteBuf;)V
 }
 
+public final class org/quiltmc/qkl/library/networking/serialization/PacketByteBufEncoder$Companion {
+}
+
 public final class org/quiltmc/qkl/library/networking/serialization/SerializedClientPlayNetworking {
 	public static final field INSTANCE Lorg/quiltmc/qkl/library/networking/serialization/SerializedClientPlayNetworking;
 }
 
 public final class org/quiltmc/qkl/library/networking/serialization/SerializedPacketRegistration {
-	public fun <init> (Lnet/minecraft/util/Identifier;Lorg/quiltmc/qkl/library/networking/serialization/SerializedPacketRegistration$Direction;)V
+	public fun <init> (Lnet/minecraft/util/Identifier;Lorg/quiltmc/qkl/library/networking/serialization/SerializedPacketRegistration$Direction;Lkotlinx/serialization/modules/SerializersModule;)V
 	public final fun getDirection ()Lorg/quiltmc/qkl/library/networking/serialization/SerializedPacketRegistration$Direction;
 	public final fun getId ()Lnet/minecraft/util/Identifier;
 	public final fun getOnClientReceiveAction ()Lkotlin/jvm/functions/Function4;
 	public final fun getOnServerReceiveAction ()Lkotlin/jvm/functions/Function5;
+	public final fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
 	public final fun onClientReceive (Lkotlin/jvm/functions/Function4;)V
 	public final fun onServerReceive (Lkotlin/jvm/functions/Function5;)V
 	public final fun setOnClientReceiveAction (Lkotlin/jvm/functions/Function4;)V

--- a/library/src/main/kotlin/org/quiltmc/qkl/library/networking/serialization/PacketByteBufDecoder.kt
+++ b/library/src/main/kotlin/org/quiltmc/qkl/library/networking/serialization/PacketByteBufDecoder.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qkl.library.networking.serialization
+
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.AbstractDecoder
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.modules.EmptySerializersModule
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.serializer
+import net.minecraft.network.PacketByteBuf
+
+/**
+ * An [AbstractDecoder] that is capable of reading a class from a packet byte buf
+ */
+@OptIn(ExperimentalSerializationApi::class)
+public class PacketByteBufDecoder(
+    public val input: PacketByteBuf,
+    override val serializersModule: SerializersModule = EmptySerializersModule()
+) : AbstractDecoder() {
+    private val byteArraySerializer = serializer<ByteArray>()
+    private var elementIndex = 0
+    override fun decodeSequentially(): Boolean = true
+
+    override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T {
+        if (deserializer.descriptor == byteArraySerializer.descriptor) {
+            @Suppress("UNCHECKED_CAST")
+            return input.readByteArray() as T
+        } else {
+            return super.decodeSerializableValue(deserializer)
+        }
+    }
+
+    override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
+        if (input.readerIndex() >= input.readableBytes()) return CompositeDecoder.DECODE_DONE
+        return elementIndex++
+    }
+
+    override fun decodeBoolean(): Boolean {
+        return input.readBoolean()
+    }
+    override fun decodeByte(): Byte {
+        return input.readByte()
+    }
+    override fun decodeChar(): Char {
+        return input.readChar()
+    }
+    override fun decodeShort(): Short {
+        return input.readShort()
+    }
+    override fun decodeInt(): Int {
+        return input.readInt()
+    }
+    override fun decodeLong(): Long {
+        return input.readLong()
+    }
+    override fun decodeFloat(): Float {
+        return input.readFloat()
+    }
+    override fun decodeDouble(): Double {
+        return input.readDouble()
+    }
+    override fun decodeString(): String {
+        return input.readString()
+    }
+    override fun decodeEnum(enumDescriptor: SerialDescriptor): Int {
+        return input.readVarInt()
+    }
+
+    override fun decodeNotNullMark(): Boolean {
+        return input.readBoolean()
+    }
+
+    override fun decodeCollectionSize(descriptor: SerialDescriptor): Int {
+        return input.readVarInt()
+    }
+}

--- a/library/src/main/kotlin/org/quiltmc/qkl/library/networking/serialization/PacketByteBufDecoder.kt
+++ b/library/src/main/kotlin/org/quiltmc/qkl/library/networking/serialization/PacketByteBufDecoder.kt
@@ -95,7 +95,7 @@ public class PacketByteBufDecoder(
         /**
          * Decodes a [PacketByteBuf] to an instance of [T]
          */
-        public inline fun <reified T> decodeFrom(
+        public inline fun <reified T> decode(
             packetByteBuf: PacketByteBuf,
             serializersModule: SerializersModule = EmptySerializersModule()
         ): T {

--- a/library/src/main/kotlin/org/quiltmc/qkl/library/networking/serialization/PacketByteBufDecoder.kt
+++ b/library/src/main/kotlin/org/quiltmc/qkl/library/networking/serialization/PacketByteBufDecoder.kt
@@ -90,4 +90,16 @@ public class PacketByteBufDecoder(
     override fun decodeCollectionSize(descriptor: SerialDescriptor): Int {
         return input.readVarInt()
     }
+
+    public companion object {
+        /**
+         * Decodes a [PacketByteBuf] to an instance of [T]
+         */
+        public inline fun <reified T> decodeFrom(
+            packetByteBuf: PacketByteBuf,
+            serializersModule: SerializersModule = EmptySerializersModule()
+        ): T {
+            return PacketByteBufDecoder(packetByteBuf, serializersModule).decodeSerializableValue(serializer())
+        }
+    }
 }

--- a/library/src/main/kotlin/org/quiltmc/qkl/library/networking/serialization/PacketByteBufEncoder.kt
+++ b/library/src/main/kotlin/org/quiltmc/qkl/library/networking/serialization/PacketByteBufEncoder.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2023 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qkl.library.networking.serialization
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.AbstractDecoder
+import kotlinx.serialization.encoding.AbstractEncoder
+import kotlinx.serialization.encoding.CompositeEncoder
+import kotlinx.serialization.modules.EmptySerializersModule
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.serializer
+import net.minecraft.network.PacketByteBuf
+import org.quiltmc.qsl.networking.api.PacketByteBufs
+
+/**
+ * An [AbstractDecoder] that is capable of writing a class to a packet byte buf
+ */
+@OptIn(ExperimentalSerializationApi::class)
+public class PacketByteBufEncoder(
+    override val serializersModule: SerializersModule = EmptySerializersModule()
+) : AbstractEncoder() {
+    private val byteArraySerializer = serializer<ByteArray>()
+
+    public var packetByteBuf: PacketByteBuf = PacketByteBufs.create()
+
+    override fun <T> encodeSerializableValue(serializer: SerializationStrategy<T>, value: T) {
+        if (serializer.descriptor == byteArraySerializer.descriptor) {
+            packetByteBuf.writeByteArray(value as ByteArray)
+        } else {
+            super.encodeSerializableValue(serializer, value)
+        }
+    }
+
+    override fun encodeBoolean(value: Boolean) {
+        packetByteBuf.writeBoolean(value)
+    }
+
+    override fun encodeByte(value: Byte) {
+        packetByteBuf.writeByte(value.toInt())
+    }
+
+    override fun encodeChar(value: Char) {
+        packetByteBuf.writeChar(value.code)
+    }
+
+    override fun encodeShort(value: Short) {
+        packetByteBuf.writeShort(value.toInt())
+    }
+
+    override fun encodeInt(value: Int) {
+        packetByteBuf.writeInt(value)
+    }
+
+    override fun encodeLong(value: Long) {
+        packetByteBuf.writeLong(value)
+    }
+
+    override fun encodeFloat(value: Float) {
+        packetByteBuf.writeFloat(value)
+    }
+
+    override fun encodeDouble(value: Double) {
+        packetByteBuf.writeDouble(value)
+    }
+
+    override fun encodeString(value: String) {
+        packetByteBuf.writeString(value)
+    }
+
+    @ExperimentalSerializationApi
+    override fun encodeNotNullMark() {
+        encodeBoolean(true)
+    }
+
+    @ExperimentalSerializationApi
+    override fun encodeNull() {
+        encodeBoolean(false)
+    }
+
+    override fun encodeEnum(enumDescriptor: SerialDescriptor, index: Int) {
+        packetByteBuf.writeVarInt(index)
+    }
+
+    override fun beginCollection(descriptor: SerialDescriptor, collectionSize: Int): CompositeEncoder {
+        packetByteBuf.writeVarInt(collectionSize)
+        return this
+    }
+}

--- a/library/src/main/kotlin/org/quiltmc/qkl/library/networking/serialization/PacketByteBufEncoder.kt
+++ b/library/src/main/kotlin/org/quiltmc/qkl/library/networking/serialization/PacketByteBufEncoder.kt
@@ -17,6 +17,7 @@
 package org.quiltmc.qkl.library.networking.serialization
 
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.AbstractDecoder
@@ -100,5 +101,19 @@ public class PacketByteBufEncoder(
     override fun beginCollection(descriptor: SerialDescriptor, collectionSize: Int): CompositeEncoder {
         packetByteBuf.writeVarInt(collectionSize)
         return this
+    }
+
+    public companion object {
+        /**
+         * Encodes an instance of [T] and returns the [PacketByteBuf].
+         */
+        public inline fun <reified T> encode(
+            value: @Serializable T,
+            serializersModule: SerializersModule = EmptySerializersModule()
+        ): PacketByteBuf {
+            val encoder = PacketByteBufEncoder(serializersModule)
+            encoder.encodeSerializableValue(serializer(), value)
+            return encoder.packetByteBuf
+        }
     }
 }

--- a/library/src/main/kotlin/org/quiltmc/qkl/library/networking/serialization/serializedPacketRegistration.kt
+++ b/library/src/main/kotlin/org/quiltmc/qkl/library/networking/serialization/serializedPacketRegistration.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2023 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qkl.library.networking.serialization
+
+import kotlinx.serialization.serializer
+import net.minecraft.client.MinecraftClient
+import net.minecraft.client.network.ClientPlayNetworkHandler
+import net.minecraft.server.MinecraftServer
+import net.minecraft.server.network.ServerPlayNetworkHandler
+import net.minecraft.server.network.ServerPlayerEntity
+import net.minecraft.util.Identifier
+import org.quiltmc.qsl.networking.api.PacketSender
+import org.quiltmc.qsl.networking.api.ServerPlayNetworking
+import org.quiltmc.qsl.networking.api.client.ClientPlayNetworking
+
+public typealias OnSerializedPacketClient<T> =
+        T.(MinecraftClient, ClientPlayNetworkHandler, PacketSender)->Unit
+public typealias OnSerializedPacketServer<T> =
+        T.(MinecraftServer, ServerPlayerEntity, ServerPlayNetworkHandler, PacketSender)->Unit
+
+/**
+ * A utility class for serialized packet registration.
+ * @param id The packet channel to expect this packet on.
+ * @param direction The directions that this packet can be sent in.
+ */
+public class SerializedPacketRegistration<P>(public val id: Identifier, public val direction: Direction) {
+    /**
+     * Action to be executed when this packet is received on the client.
+     */
+    public var onClientReceiveAction: OnSerializedPacketClient<P>? = null
+    /**
+     * Action to be executed when this packet is received on the server.
+     */
+    public var onServerReceiveAction: OnSerializedPacketServer<P>? = null
+
+    /**
+     * Registers a method to use for receiving this packet on the client side.
+     */
+    public fun onClientReceive(action: OnSerializedPacketClient<P>) {
+        onClientReceiveAction = action
+    }
+
+    /**
+     * Registers a method to use for receiving this packet on the server side.
+     */
+    public fun onServerReceive(action: OnSerializedPacketServer<P>) {
+        onServerReceiveAction = action
+    }
+
+    /**
+     * Finishes building and registers the relevant listeners.
+     * Usually should not be invoked manually, prefer use of [registerSerializedPacket].
+     */
+    public inline fun <reified T> finalize() {
+        if (direction == Direction.ClientToServer || direction == Direction.BiDirectional) {
+            if (onServerReceiveAction == null) {
+                throw IllegalStateException(
+                    "No action set for receiving on the server with packet direction ${direction.name}"
+                )
+            }
+
+            ServerPlayNetworking
+                .registerGlobalReceiver(id) { server, serverPlayer, playNetworking, packetByteBuf, sender ->
+                val decoded = PacketByteBufDecoder(packetByteBuf).decodeSerializableValue<T>(serializer())
+                server.execute {
+                    @Suppress("UNCHECKED_CAST")
+                    onServerReceiveAction!!.invoke(decoded as P, server, serverPlayer, playNetworking, sender)
+                }
+            }
+        }
+
+        if (direction == Direction.ServerToClient || direction == Direction.BiDirectional) {
+            if (onClientReceiveAction == null) {
+                throw IllegalStateException(
+                    "No action set for receiving on the client with packet direction ${direction.name}"
+                )
+            }
+
+            ClientPlayNetworking.registerGlobalReceiver(id) { client, playNetworking, packetByteBuf, sender ->
+                val decoded = PacketByteBufDecoder(packetByteBuf).decodeSerializableValue<T>(serializer())
+                client.execute {
+                    @Suppress("UNCHECKED_CAST")
+                    onClientReceiveAction!!.invoke(decoded as P, client, playNetworking, sender)
+                }
+            }
+        }
+    }
+
+    /**
+     * An enum used to give the direction that a packet may be received from during registration.
+     */
+    public enum class Direction {
+        ClientToServer,
+        ServerToClient,
+        BiDirectional
+    }
+}
+
+/**
+ * Allows registering a serialized packet that automatically decodes and executes on the correct thread.
+ */
+public inline fun <reified T> registerSerializedPacket(
+    id: Identifier,
+    direction: SerializedPacketRegistration.Direction,
+    action: SerializedPacketRegistration<T>.()->Unit
+) {
+    SerializedPacketRegistration<T>(id, direction).apply(action).finalize<T>()
+}

--- a/library/src/main/kotlin/org/quiltmc/qkl/library/networking/serialization/serializedPacketRegistration.kt
+++ b/library/src/main/kotlin/org/quiltmc/qkl/library/networking/serialization/serializedPacketRegistration.kt
@@ -81,7 +81,7 @@ public class SerializedPacketRegistration<P>(
 
             ServerPlayNetworking
                 .registerGlobalReceiver(id) { server, serverPlayer, playNetworking, packetByteBuf, sender ->
-                val decoded = PacketByteBufDecoder.decodeFrom<T>(packetByteBuf, serializersModule)
+                val decoded = PacketByteBufDecoder.decode<T>(packetByteBuf, serializersModule)
                 server.execute {
                     @Suppress("UNCHECKED_CAST")
                     onServerReceiveAction!!.invoke(decoded as P, server, serverPlayer, playNetworking, sender)
@@ -97,7 +97,7 @@ public class SerializedPacketRegistration<P>(
             }
 
             ClientPlayNetworking.registerGlobalReceiver(id) { client, playNetworking, packetByteBuf, sender ->
-                val decoded = PacketByteBufDecoder.decodeFrom<T>(packetByteBuf, serializersModule)
+                val decoded = PacketByteBufDecoder.decode<T>(packetByteBuf, serializersModule)
                 client.execute {
                     @Suppress("UNCHECKED_CAST")
                     onClientReceiveAction!!.invoke(decoded as P, client, playNetworking, sender)

--- a/library/src/main/kotlin/org/quiltmc/qkl/library/networking/serialization/serializedPacketSending.kt
+++ b/library/src/main/kotlin/org/quiltmc/qkl/library/networking/serialization/serializedPacketSending.kt
@@ -17,7 +17,8 @@
 package org.quiltmc.qkl.library.networking.serialization
 
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.serializer
+import kotlinx.serialization.modules.EmptySerializersModule
+import kotlinx.serialization.modules.SerializersModule
 import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.util.Identifier
 import org.quiltmc.loader.api.minecraft.ClientOnly
@@ -34,10 +35,12 @@ public object SerializedClientPlayNetworking {
     /**
      * Serializes and sends a packet object from the client to the server.
      */
-    public inline fun <reified T> send(id: Identifier, obj: @Serializable T) {
-        val encoder = PacketByteBufEncoder()
-        encoder.encodeSerializableValue(serializer(), obj)
-        ClientPlayNetworking.send(id, encoder.packetByteBuf)
+    public inline fun <reified T> send(
+        id: Identifier,
+        obj: @Serializable T,
+        serializersModule: SerializersModule = EmptySerializersModule()
+    ) {
+        ClientPlayNetworking.send(id, PacketByteBufEncoder.encode(obj, serializersModule))
     }
 }
 
@@ -50,18 +53,24 @@ public object SerializedServerPlayNetworking {
     /**
      * Serializes and sends a packet object from the server to a player.
      */
-    public inline fun <reified T> send(player: ServerPlayerEntity, id: Identifier, obj: @Serializable T) {
-        val encoder = PacketByteBufEncoder()
-        encoder.encodeSerializableValue(serializer(), obj)
-        ServerPlayNetworking.send(player, id, encoder.packetByteBuf)
+    public inline fun <reified T> send(
+        player: ServerPlayerEntity,
+        id: Identifier,
+        obj: @Serializable T,
+        serializersModule: SerializersModule = EmptySerializersModule()
+    ) {
+        ServerPlayNetworking.send(player, id, PacketByteBufEncoder.encode(obj, serializersModule))
     }
 
     /**
      * Serializes and sends a packet object from the server to the provided players.
      */
-    public inline fun <reified T> send(players: Collection<ServerPlayerEntity>, id: Identifier, obj: @Serializable T) {
-        val encoder = PacketByteBufEncoder()
-        encoder.encodeSerializableValue(serializer(), obj)
-        ServerPlayNetworking.send(players, id, encoder.packetByteBuf)
+    public inline fun <reified T> send(
+        players: Collection<ServerPlayerEntity>,
+        id: Identifier,
+        obj: @Serializable T,
+        serializersModule: SerializersModule = EmptySerializersModule()
+    ) {
+        ServerPlayNetworking.send(players, id, PacketByteBufEncoder.encode(obj, serializersModule))
     }
 }

--- a/library/src/main/kotlin/org/quiltmc/qkl/library/networking/serialization/serializedPacketSending.kt
+++ b/library/src/main/kotlin/org/quiltmc/qkl/library/networking/serialization/serializedPacketSending.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qkl.library.networking.serialization
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.serializer
+import net.minecraft.server.network.ServerPlayerEntity
+import net.minecraft.util.Identifier
+import org.quiltmc.loader.api.minecraft.ClientOnly
+import org.quiltmc.qsl.networking.api.ServerPlayNetworking
+import org.quiltmc.qsl.networking.api.client.ClientPlayNetworking
+
+/**
+ * A utility object for sending serialized objects from the client to the server.
+ *
+ * @see ClientPlayNetworking
+ */
+@ClientOnly
+public object SerializedClientPlayNetworking {
+    /**
+     * Serializes and sends a packet object from the client to the server.
+     */
+    public inline fun <reified T> send(id: Identifier, obj: @Serializable T) {
+        val encoder = PacketByteBufEncoder()
+        encoder.encodeSerializableValue(serializer(), obj)
+        ClientPlayNetworking.send(id, encoder.packetByteBuf)
+    }
+}
+
+/**
+ * A utility object for sending serialized objects from the server to players.
+ *
+ * @see ServerPlayNetworking
+ */
+public object SerializedServerPlayNetworking {
+    /**
+     * Serializes and sends a packet object from the server to a player.
+     */
+    public inline fun <reified T> send(player: ServerPlayerEntity, id: Identifier, obj: @Serializable T) {
+        val encoder = PacketByteBufEncoder()
+        encoder.encodeSerializableValue(serializer(), obj)
+        ServerPlayNetworking.send(player, id, encoder.packetByteBuf)
+    }
+
+    /**
+     * Serializes and sends a packet object from the server to the provided players.
+     */
+    public inline fun <reified T> send(players: Collection<ServerPlayerEntity>, id: Identifier, obj: @Serializable T) {
+        val encoder = PacketByteBufEncoder()
+        encoder.encodeSerializableValue(serializer(), obj)
+        ServerPlayNetworking.send(players, id, encoder.packetByteBuf)
+    }
+}

--- a/library/src/main/kotlin/samples/qkl/networking/NetworkingSerializationSamples.kt
+++ b/library/src/main/kotlin/samples/qkl/networking/NetworkingSerializationSamples.kt
@@ -18,6 +18,7 @@ package samples.qkl.networking
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.serializer
+import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.util.Identifier
 import org.quiltmc.qkl.library.networking.serialization.*
 
@@ -75,6 +76,8 @@ private object NetworkingSerializationSamples {
 
         // Send the created data from the client to the server
         SerializedClientPlayNetworking.send(Identifier("example", "packet"), person)
+        // or vice versa
+        SerializedServerPlayNetworking.send(stub<ServerPlayerEntity>(), Identifier("example", "packet"), person)
     }
 
     @Serializable

--- a/library/src/main/kotlin/samples/qkl/networking/NetworkingSerializationSamples.kt
+++ b/library/src/main/kotlin/samples/qkl/networking/NetworkingSerializationSamples.kt
@@ -50,7 +50,7 @@ private object NetworkingSerializationSamples {
         }
 
         // Read it from a packet byte buf (in this case, the one we just created)
-        val andBackAgain = PacketByteBufDecoder.decodeFrom<TestPerson>(asByteBuf)
+        val andBackAgain = PacketByteBufDecoder.decode<TestPerson>(asByteBuf)
         // or, if you need more control such as a serializers module
         val andBackAgain2 = PacketByteBufDecoder(asByteBuf, serializersModule = stub())
             .decodeSerializableValue<TestPerson>(serializer())

--- a/library/src/main/kotlin/samples/qkl/networking/NetworkingSerializationSamples.kt
+++ b/library/src/main/kotlin/samples/qkl/networking/NetworkingSerializationSamples.kt
@@ -21,9 +21,13 @@ import kotlinx.serialization.serializer
 import net.minecraft.util.Identifier
 import org.quiltmc.qkl.library.networking.serialization.*
 
-@Suppress("unused")
+@Suppress("unused", "UNUSED_VARIABLE")
 private object NetworkingSerializationSamples {
     val age = 19
+
+    fun <T> stub(): T {
+        TODO()
+    }
 
     fun example() {
         // Define the data
@@ -38,13 +42,18 @@ private object NetworkingSerializationSamples {
         )
 
         // Encode to a packet byte buf
-        val asByteBuf = PacketByteBufEncoder().let {
+        val asByteBuf = PacketByteBufEncoder.encode(person)
+        // or, if you need more control such as a serializers module
+        val asByteBuf2 = PacketByteBufEncoder(serializersModule = stub()).let {
             it.encodeSerializableValue(serializer(), person)
             it.packetByteBuf
         }
 
         // Read it from a packet byte buf (in this case, the one we just created)
-        val andBackAgain = PacketByteBufDecoder(asByteBuf).decodeSerializableValue<TestPerson>(serializer())
+        val andBackAgain = PacketByteBufDecoder.decodeFrom<TestPerson>(asByteBuf)
+        // or, if you need more control such as a serializers module
+        val andBackAgain2 = PacketByteBufDecoder(asByteBuf, serializersModule = stub())
+            .decodeSerializableValue<TestPerson>(serializer())
         assert(person == andBackAgain)
 
         // Register a bi-directional packet of type `TestPerson`

--- a/library/src/main/kotlin/samples/qkl/networking/NetworkingSerializationSamples.kt
+++ b/library/src/main/kotlin/samples/qkl/networking/NetworkingSerializationSamples.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package samples.qkl.networking
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.serializer
+import net.minecraft.util.Identifier
+import org.quiltmc.qkl.library.networking.serialization.*
+
+@Suppress("unused")
+private object NetworkingSerializationSamples {
+    val age = 19
+
+    fun example() {
+        // Define the data
+        val person = TestPerson(
+            "Silver",
+            age,
+            null,
+            setOf(
+                Pronouns("it/its"),
+                Pronouns("she/her")
+            )
+        )
+
+        // Encode to a packet byte buf
+        val asByteBuf = PacketByteBufEncoder().let {
+            it.encodeSerializableValue(serializer(), person)
+            it.packetByteBuf
+        }
+
+        // Read it from a packet byte buf (in this case, the one we just created)
+        val andBackAgain = PacketByteBufDecoder(asByteBuf).decodeSerializableValue<TestPerson>(serializer())
+        assert(person == andBackAgain)
+
+        // Register a bi-directional packet of type `TestPerson`
+        // that can be send both ways on the `example:packet` channel
+        registerSerializedPacket<TestPerson>(
+            Identifier("example", "packet"),
+            SerializedPacketRegistration.Direction.BiDirectional
+        ) {
+            // When we get a packet on the client
+            onClientReceive { minecraftClient, clientPlayNetworkHandler, packetSender ->
+                println("Got person on client! $this")
+            }
+
+            // When we get a packet on the server
+            onServerReceive { minecraftServer, serverPlayerEntity, serverPlayNetworkHandler, packetSender ->
+                println("Got person on server! $this")
+            }
+        }
+
+        // Send the created data from the client to the server
+        SerializedClientPlayNetworking.send(Identifier("example", "packet"), person)
+    }
+
+    @Serializable
+    data class Pronouns(val value: String)
+
+    @Serializable
+    data class TestPerson(val name: String, val age: Int, val gender: ByteArray?, val pronouns: Set<Pronouns>)
+}


### PR DESCRIPTION
yeah 😎 

Inspired by the concept of https://github.com/FabricMC/fabric/pull/2820, banged out during class so might have fucked up some stuff.

Wasnt able to include a lot of the goodies like `encodeNbt` and whatever because we dont have serializers for those atm, worth looking into if its possible with mixin or if we need chasm?

Keeps compat with any java users wanting to parse this, nulls are encoded the same way as `Optional`s and such, as you can see in this diagram of the serialized form of the sample data
<img width="1010" alt="serialized_packet" src="https://user-images.githubusercontent.com/52360088/229937088-9e8c578c-6910-444e-9d6c-55fcb79b729b.png">
