### PR TITLE
Add dependency additional libraries to QKL

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,8 +37,7 @@ group = "org.quiltmc"
 val rootVersion = project.version
 val flkVersion: String by project
 version = "${project.version}+kt.${project.libs.versions.kotlin.orNull}+flk.$flkVersion"
-val projectVersion =
-    project.version as String + if (System.getenv("SNAPSHOTS_URL") != null && System.getenv("MAVEN_URL") == null) "-SNAPSHOT" else ""
+val projectVersion = project.version as String + if (System.getenv("SNAPSHOTS_URL") != null && System.getenv("MAVEN_URL") == null) "-SNAPSHOT" else ""
 
 val javaVersion = 17 // The current version of Java used by Minecraft
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,8 @@ group = "org.quiltmc"
 val rootVersion = project.version
 val flkVersion: String by project
 version = "${project.version}+kt.${project.libs.versions.kotlin.orNull}+flk.$flkVersion"
-val projectVersion = project.version as String + if (System.getenv("SNAPSHOTS_URL") != null && System.getenv("MAVEN_URL") == null) "-SNAPSHOT" else ""
+val projectVersion =
+    project.version as String + if (System.getenv("SNAPSHOTS_URL") != null && System.getenv("MAVEN_URL") == null) "-SNAPSHOT" else ""
 
 val javaVersion = 17 // The current version of Java used by Minecraft
 
@@ -50,18 +51,29 @@ fun DependencyHandlerScope.includeApi(dependency: Any) {
     include(dependency)
 }
 
+fun DependencyHandlerScope.includeModApi(dependency: Provider<MinimalExternalModuleDependency>) {
+    include(dependency)
+    modApi(dependency) {
+        exclude(group = "net.fabricmc")
+    }
+}
+
 dependencies {
     includeApi(project(":core", configuration = "namedElements"))
     includeApi(project(":library", configuration = "namedElements"))
+
+    includeModApi(libs.serialization.minecraft)
+    includeApi(libs.collections.immutable)
+    includeApi(libs.klogging)
 }
 
 allprojects {
-    apply(plugin=rootProject.libs.plugins.kotlin.get().pluginId)
-    apply(plugin=rootProject.libs.plugins.detekt.get().pluginId)
-    apply(plugin=rootProject.libs.plugins.licenser.get().pluginId)
-    apply(plugin=rootProject.libs.plugins.dokka.get().pluginId)
-    apply(plugin="maven-publish")
-    apply(plugin=rootProject.libs.plugins.quilt.loom.get().pluginId)
+    apply(plugin = rootProject.libs.plugins.kotlin.get().pluginId)
+    apply(plugin = rootProject.libs.plugins.detekt.get().pluginId)
+    apply(plugin = rootProject.libs.plugins.licenser.get().pluginId)
+    apply(plugin = rootProject.libs.plugins.dokka.get().pluginId)
+    apply(plugin = "maven-publish")
+    apply(plugin = rootProject.libs.plugins.quilt.loom.get().pluginId)
 
     repositories {
         mavenCentral()
@@ -307,17 +319,17 @@ tasks.curseforge.get().dependsOn(project(":core").tasks.remapJar)
 
 modrinth {
     token.set(System.getenv("MODRINTH_TOKEN"))
-    
+
     projectId.set("qkl")
     versionName.set("QKL $rootVersion + FLK $flkVersion + Kotlin ${project.libs.versions.kotlin.orNull}")
     versionType.set("release")
-    
+
     changelog.set(System.getenv("CHANGELOG") ?: "No changelog provided.")
 
     file.set(tasks.remapJar.get().archiveFile)
     additionalFiles.add(project(":core").tasks.remapJar.get().archiveFile)
-    
-    dependencies { 
+
+    dependencies {
         required.project("qsl")
         embedded.project("fabric-language-kotlin")
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,23 +1,28 @@
 [versions]
 atomic = "0.21.0"
+collections_immutable = "0.3.5"
 coroutines = "1.7.2"
 datetime = "0.4.0"
 dokka = "1.8.20"
+klogging = "5.1.0"
 kotlin = "1.9.0"
 minecraft = "1.20.1"
 qsl = "6.0.4+1.20.1"
 quilt_loader = "0.19.2"
 quilt_mappings = "1.20.1+build.21"
 serialization = "1.5.1"
+serialization_minecraft = "2.0.0+1.20.1"
 serialization_plugin = "1.9.0" # usually same as kotlin but can lag behind
 binary_compat_plugin = "0.13.2"
 
 [libraries]
 atomic = { module = "org.jetbrains.kotlinx:atomicfu-jvm", version.ref = "atomic" }
+collections_immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm", version.ref = "collections_immutable" }
 coroutines_core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 coroutines_jdk8 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8", version.ref = "coroutines" }
 coroutines_jvm = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm", version.ref = "coroutines" }
 datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime-jvm", version.ref = "datetime" }
+klogging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "klogging" }
 dokka_base = { module = "org.jetbrains.dokka:dokka-base", version.ref = "dokka" }
 minecraft = { module = "com.mojang:minecraft", version.ref = "minecraft" }
 qsl = { module = "org.quiltmc:qsl", version.ref = "qsl" }
@@ -26,6 +31,7 @@ quilt_mappings = { module = "org.quiltmc:quilt-mappings", version.ref = "quilt_m
 serialization_cbor = { module = "org.jetbrains.kotlinx:kotlinx-serialization-cbor-jvm", version.ref = "serialization" }
 serialization_core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm", version.ref = "serialization" }
 serialization_json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json-jvm", version.ref = "serialization" }
+serialization_minecraft = { module = "io.github.natanfudge:kotlinx-serialization-minecraft", version.ref = "serialization_minecraft" }
 
 [plugins]
 detekt = { id = "io.gitlab.arturbosch.detekt", version = "1.23.0" }


### PR DESCRIPTION
- [KotlinX Serialization for Minecraft](https://github.com/natanfudge/Kotlinx-Serialization-Minecraft) is a fabric library that allows serialization of Minecraft classes such as `NBT` and `UUID`. 142 KB in size.
![the author's agreement add the library to quilt](https://github.com/QuiltMC/quilt-kotlin-libraries/assets/127752744/c228ec13-59f2-4cce-b6bc-a9052cb3404a) ([source](https://discord.com/channels/817576132726620200/1103987420686463028/1150287018279059466))
- [KotlinX Immutable Collections](https://github.com/Kotlin/kotlinx.collections.immutable) adds faster (`O(1)` instead of `O(n)`) immutable collections. 238 KB in size.
- [Oshai's Kotlin Logging](https://github.com/oshai/kotlin-logging) is a faster and prettier kotlin-first logging library implemented on top of SLF4J, used by official kotlin libraries. 157 KB in size.

These libraries are very useful - and bundling them with KQL can save storage space, preventing multiple mods from bundling them each.