### PR TITLE
fix: issues url spelling mistake

### DIFF
--- a/src/main/resources/quilt.mod.json
+++ b/src/main/resources/quilt.mod.json
@@ -12,7 +12,7 @@
       },
       "contact": {
         "homepage": "https://quiltmc.org",
-        "issues": "https://github.com/quiltmc/quilt-kotlin-libaries/issues",
+        "issues": "https://github.com/quiltmc/quilt-kotlin-libraries/issues",
         "sources": "https://github.com/quiltmc/quilt-kotlin-libraries"
       },
       "license": "Apache-2.0",


### PR DESCRIPTION
## Issue
The issues contact URL in `quilt.mod.json` has a typo, pointing to a non-existent page.

## Solution
Correct the typo, changing from `quilt-kotlin-libaries` to `quilt-kotlin-libraries`